### PR TITLE
feat: spell system and ghost keyboard tutorial (Tasks 19+22)

### DIFF
--- a/src/components/GhostKeyboard.ts
+++ b/src/components/GhostKeyboard.ts
@@ -1,0 +1,44 @@
+import Phaser from 'phaser'
+
+export class GhostKeyboard {
+  private keys: Map<string, Phaser.GameObjects.Rectangle> = new Map()
+  private labels: Map<string, Phaser.GameObjects.Text> = new Map()
+
+  constructor(private scene: Phaser.Scene, private y: number) {
+    this.buildLayout()
+  }
+
+  highlight(ch: string) {
+    this.keys.forEach((rect, key) => {
+      rect.setFillStyle(key === ch ? 0xffd700 : 0x333355)
+    })
+  }
+
+  fadeOut() {
+    this.scene.tweens.add({
+      targets: [...this.keys.values(), ...this.labels.values()],
+      alpha: 0, duration: 1000
+    })
+  }
+
+  private buildLayout() {
+    const rows = [
+      ['q','w','e','r','t','y','u','i','o','p'],
+      ['a','s','d','f','g','h','j','k','l',';'],
+      ['z','x','c','v','b','n','m',',','.','/'],
+    ]
+    const { width } = this.scene.scale
+    rows.forEach((row, rowIdx) => {
+      row.forEach((key, colIdx) => {
+        const x = width * 0.1 + colIdx * 36 + rowIdx * 18
+        const y = this.y + rowIdx * 38
+        const rect = this.scene.add.rectangle(x, y, 30, 30, 0x333355).setAlpha(0.7)
+        const label = this.scene.add.text(x, y, key, {
+          fontSize: '14px', color: '#aaaaaa'
+        }).setOrigin(0.5).setAlpha(0.7)
+        this.keys.set(key, rect)
+        this.labels.set(key, label)
+      })
+    })
+  }
+}

--- a/src/components/SpellCaster.ts
+++ b/src/components/SpellCaster.ts
@@ -1,0 +1,82 @@
+import Phaser from 'phaser'
+import { SpellData } from '../types'
+import { loadProfile } from '../utils/profile'
+import { SPELLS } from '../data/spells'
+import { TypingEngine } from './TypingEngine'
+
+export class SpellCaster {
+  private spell: SpellData | null = null
+  private used = false
+  private casting = false
+  private hintText!: Phaser.GameObjects.Text
+  private promptText!: Phaser.GameObjects.Text
+  private engine: TypingEngine
+  private onSpellEffect: (effect: SpellData['effect']) => void = () => {}
+
+  constructor(
+    private scene: Phaser.Scene,
+    profileSlot: number,
+    engine: TypingEngine,
+  ) {
+    this.engine = engine
+    const profile = loadProfile(profileSlot)
+    if (profile && profile.spells.length > 0) {
+      this.spell = SPELLS.find(s => s.id === profile.spells[0]) ?? null
+    }
+    this.buildHud()
+    this.scene.input.keyboard?.on('keydown-TAB', this.onTab, this)
+  }
+
+  setEffectCallback(cb: (effect: SpellData['effect']) => void) {
+    this.onSpellEffect = cb
+  }
+
+  private buildHud() {
+    const { width, height } = this.scene.scale
+    if (this.spell) {
+      this.hintText = this.scene.add.text(width - 16, height - 16,
+        `✨ ${this.spell.name} [TAB]`, {
+          fontSize: '18px', color: '#aaaaff', backgroundColor: '#000022',
+          padding: { x: 6, y: 3 }
+        }).setOrigin(1, 1).setDepth(10)
+    } else {
+      this.hintText = this.scene.add.text(0, 0, '').setVisible(false)
+    }
+    this.promptText = this.scene.add.text(this.scene.scale.width / 2, this.scene.scale.height / 2 - 60,
+      '', { fontSize: '28px', color: '#ffd700', backgroundColor: '#000033',
+            padding: { x: 10, y: 6 } }).setOrigin(0.5).setDepth(11).setVisible(false)
+  }
+
+  private onTab() {
+    if (!this.spell || this.used || this.casting) return
+    this.casting = true
+    this.promptText.setText(`Cast spell — type: ${this.spell.name.toUpperCase()}`).setVisible(true)
+    const spellWord = this.spell.name.toLowerCase()
+    this.engine.setWord(spellWord)
+    this.engine.setOnCompleteOverride((word: string) => {
+      if (word === spellWord) {
+        this.used = true
+        this.casting = false
+        this.promptText.setVisible(false)
+        this.hintText.setText(`✨ ${this.spell!.name} (used)`)
+        this.onSpellEffect(this.spell!.effect)
+        this.showCastBanner()
+      }
+    })
+  }
+
+  private showCastBanner() {
+    const { width, height } = this.scene.scale
+    const banner = this.scene.add.text(width / 2, height / 2,
+      '✨ SPELL CAST! ✨', {
+        fontSize: '48px', color: '#ffd700', fontStyle: 'bold'
+      }).setOrigin(0.5).setDepth(12)
+    this.scene.time.delayedCall(1200, () => banner.destroy())
+  }
+
+  destroy() {
+    this.scene.input.keyboard?.off('keydown-TAB', this.onTab, this)
+    this.hintText?.destroy()
+    this.promptText?.destroy()
+  }
+}

--- a/src/components/TypingEngine.ts
+++ b/src/components/TypingEngine.ts
@@ -25,6 +25,7 @@ export class TypingEngine {
   totalKeystrokes = 0
   completedWords = 0
   sessionStartTime = 0
+  private _onCompleteOverride?: (word: string, elapsed: number) => void
 
   constructor(config: TypingEngineConfig) {
     this.config = config
@@ -61,6 +62,10 @@ export class TypingEngine {
     return this.currentWord
   }
 
+  setOnCompleteOverride(cb: (word: string, elapsed: number) => void) {
+    this._onCompleteOverride = cb
+  }
+
   private handleKey(event: KeyboardEvent) {
     if (!this.currentWord) return
     const key = event.key.toLowerCase()
@@ -76,7 +81,11 @@ export class TypingEngine {
       if (this.typedSoFar === this.currentWord) {
         this.completedWords++
         const elapsed = Date.now() - this.wordStartTime
-        this.config.onWordComplete(this.currentWord, elapsed)
+        const word = this.currentWord
+        const override = this._onCompleteOverride
+        this._onCompleteOverride = undefined
+        this.config.onWordComplete(word, elapsed)
+        if (override) override(word, elapsed)
         this.clearWord()
       }
     } else {

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -1,0 +1,8 @@
+import { SpellData } from '../types'
+
+export const SPELLS: SpellData[] = [
+  { id: 'time_freeze', name: 'Glacius', description: 'Freezes all enemies for 5 seconds.', effect: 'time_freeze' },
+  { id: 'word_blast', name: 'Obliterus', description: 'Destroys the nearest enemy instantly.', effect: 'word_blast' },
+  { id: 'second_chance', name: 'Revivus', description: 'Restores 2 HP.', effect: 'second_chance' },
+  { id: 'letter_shield', name: 'Errantus', description: "Next 3 wrong keys don't count.", effect: 'letter_shield' },
+]

--- a/src/scenes/level-types/GoblinWhackerLevel.ts
+++ b/src/scenes/level-types/GoblinWhackerLevel.ts
@@ -2,6 +2,9 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { GhostKeyboard } from '../../components/GhostKeyboard'
+import { SpellCaster } from '../../components/SpellCaster'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -31,6 +34,9 @@ export class GoblinWhackerLevel extends Phaser.Scene {
   private spawnTimer?: Phaser.Time.TimerEvent
   private goblinsDefeated = 0
   private finished = false
+  private spellCaster?: SpellCaster
+  private letterShieldCount = 0
+  private ghostKeyboard?: GhostKeyboard
 
   constructor() { super('GoblinWhackerLevel') }
 
@@ -71,6 +77,37 @@ export class GoblinWhackerLevel extends Phaser.Scene {
       onWordComplete: this.onWordComplete.bind(this),
       onWrongKey: this.onWrongKey.bind(this),
     })
+
+    // Spell system
+    const spellProfile = loadProfile(this.profileSlot)
+    if (spellProfile && spellProfile.spells.length > 0) {
+      this.spellCaster = new SpellCaster(this, this.profileSlot, this.engine)
+      this.spellCaster.setEffectCallback((effect) => {
+        if (effect === 'time_freeze') {
+          this.goblins.forEach(g => { g.speed = 0 })
+          this.time.delayedCall(5000, () => {
+            this.goblins.forEach(g => { g.speed = 60 + this.level.world * 10 })
+          })
+        } else if (effect === 'word_blast') {
+          const nearest = this.goblins.reduce<Goblin | null>((min, g) =>
+            !min || g.x < min.x ? g : min, null)
+          if (nearest) { this.removeGoblin(nearest); this.goblinsDefeated++ }
+        } else if (effect === 'second_chance') {
+          this.playerHp = Math.min(this.playerHp + 2, 5)
+          this.hpText.setText(`HP: ${'❤️'.repeat(this.playerHp)}`)
+        } else if (effect === 'letter_shield') {
+          this.letterShieldCount = 3
+        }
+      })
+    }
+
+    // Ghost keyboard for World 1 tutorial
+    if (this.level.world === 1 && ['w1_l1', 'w1_l2'].includes(this.level.id)) {
+      this.ghostKeyboard = new GhostKeyboard(this, height - 200)
+      if (this.activeGoblin) {
+        this.ghostKeyboard.highlight(this.activeGoblin.word[0])
+      }
+    }
 
     // Word pool
     const difficulty = Math.ceil(this.level.world / 2)
@@ -118,6 +155,9 @@ export class GoblinWhackerLevel extends Phaser.Scene {
     this.activeGoblin = goblin
     if (goblin) {
       this.engine.setWord(goblin.word)
+      if (this.ghostKeyboard) {
+        this.ghostKeyboard.highlight(goblin.word[0])
+      }
     } else {
       this.engine.clearWord()
     }
@@ -137,9 +177,6 @@ export class GoblinWhackerLevel extends Phaser.Scene {
   }
 
   private goblinReachedPlayer(goblin: Goblin) {
-    // Check companion/pet auto-strike first
-    // (simplified — full companion logic in Task 20)
-    // Removed unused loadProfile to fix lint error
     this.removeGoblin(goblin)
     this.playerHp--
     this.hpText.setText(`HP: ${'❤️'.repeat(Math.max(0, this.playerHp))}`)
@@ -163,6 +200,10 @@ export class GoblinWhackerLevel extends Phaser.Scene {
   }
 
   private onWrongKey() {
+    if (this.letterShieldCount > 0) {
+      this.letterShieldCount--
+      return
+    }
     this.cameras.main.flash(80, 120, 0, 0)
   }
 
@@ -177,6 +218,8 @@ export class GoblinWhackerLevel extends Phaser.Scene {
     this.finished = true
     this.timerEvent?.remove()
     this.spawnTimer?.remove()
+    this.spellCaster?.destroy()
+    this.ghostKeyboard?.fadeOut()
     this.engine.destroy()
 
     const elapsed = Date.now() - this.engine.sessionStartTime


### PR DESCRIPTION
## Summary
- Adds `SpellData` type and `SPELLS` data (4 spells: Glacius, Obliterus, Revivus, Errantus)
- Adds `SpellCaster` component — Tab key activates spell mode, player types spell name to cast
- Adds `GhostKeyboard` component — QWERTY keyboard overlay for World 1 tutorial levels
- Extends `TypingEngine` with `setOnCompleteOverride` hook for spell-name capture
- Wires SpellCaster + GhostKeyboard into `GoblinWhackerLevel`

## Test plan
- [ ] All 25 unit tests pass
- [ ] Spell data exported correctly from `src/data/spells.ts`
- [ ] SpellCaster reads active spell from profile and triggers effect callback
- [ ] GhostKeyboard renders and highlights next key correctly
- [ ] GhostKeyboard fades out after World 1 tutorial levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)