### PR TITLE
feat: Task 2 Solo Scribe and Mastery UI

### DIFF
--- a/docs/plans/2026-03-07-ancient-dragon-boss-design.md
+++ b/docs/plans/2026-03-07-ancient-dragon-boss-design.md
@@ -1,0 +1,39 @@
+# Design Doc: AncientDragonBoss Implementation
+
+## Overview
+Implement the `AncientDragonBoss` as Task 17 of Keyboard Quest. This boss introduces "Sentence Mode" where the player types full sentences instead of single words.
+
+## Mechanics
+- **Sentence Mode:** The player types a sequence of words separated by spaces.
+- **TypingEngine Update:**
+    - Support the space character (` `) as a valid key.
+    - Provide a visual indicator (`·`) for untyped spaces to help the player distinguish them.
+    - Backward compatible: Single-word levels continue to work without change.
+- **Phases (3 Total):**
+    - Phase 1: 2-3 words per sentence.
+    - Phase 2: 4-5 words per sentence.
+    - Phase 3: 6+ words per sentence.
+    - `wordCount` from `level.wordCount` is the total number of words across all sentences.
+- **Attacks:** Fire breath (shake/flash) occurs periodically, reducing player HP.
+
+## Architecture
+- **Scene:** `AncientDragonBoss.ts` (inherits from `Phaser.Scene`).
+- **Components:** `TypingEngine.ts` handles keyboard input and rendering.
+- **Utils:** Uses `getWordPool` from `words.ts` for sentence generation.
+
+## Implementation Details
+1.  **TypingEngine Extension:**
+    - Modify `handleKey` to treat space as a valid keystroke if it's the expected character.
+    - Update `renderWord` to render `·` when a space is expected but not yet typed.
+2.  **AncientDragonBoss Scene:**
+    - Structure it similarly to `GrizzlefangBoss`.
+    - Distribute `level.wordCount` across the 3 phases.
+    - Calculate sentences for each phase based on difficulty.
+    - Damage boss on sentence completion.
+3.  **Registration:** Add `AncientDragonBoss` to `src/main.ts`.
+
+## Testing
+- Verify that words with spaces can be typed.
+- Verify that `·` appears for spaces.
+- Verify that existing single-word levels still work as expected.
+- Verify level completion and transition to `LevelResult`.

--- a/docs/plans/2026-03-07-keyboard-quest-polish-plan.md
+++ b/docs/plans/2026-03-07-keyboard-quest-polish-plan.md
@@ -1,0 +1,139 @@
+# Keyboard Quest Phase 11 — Polish & Achievements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement final polish, tutorial hands, and the "Solo Scribe" achievement system.
+
+**Architecture:** Data-driven achievements and a new `TutorialHands` component integrated into the `TypingEngine` and `LevelResult` scenes.
+
+**Tech Stack:** TypeScript, Phaser 3, Vitest
+
+---
+
+### Task 1: Update Types and Scoring logic
+
+**Files:**
+- Modify: `src/types/index.ts`
+- Modify: `src/utils/scoring.ts`
+- Test: `src/utils/scoring.test.ts`
+
+**Step 1: Update `LevelResult` and `ProfileData` types**
+Add `companionUsed: boolean` to `LevelResult` and `worldMasteryRewards: string[]` to `ProfileData`.
+
+**Step 2: Add `checkWorldMastery` utility to `scoring.ts`**
+Implement logic to check if a world is 100% 10-starred.
+
+**Step 3: Commit**
+```bash
+git add src/types/index.ts src/utils/scoring.ts
+git commit -m "feat: update types and scoring for world mastery"
+```
+
+---
+
+### Task 2: Solo Scribe and Mastery UI in LevelResultScene
+
+**Files:**
+- Modify: `src/scenes/LevelResultScene.ts`
+
+**Step 1: Track `companionUsed` in the scene**
+If `activeCompanionId` or `activePetId` was set during the level, mark `companionUsed: true`.
+
+**Step 2: Add Solo Scribe check**
+In `create()`, check if all boss results in `profile.levelResults` have `companionUsed: false`.
+
+**Step 3: Commit**
+```bash
+git add src/scenes/LevelResultScene.ts
+git commit -m "feat: add Solo Scribe achievement logic"
+```
+
+---
+
+### Task 3: TutorialHands Component
+
+**Files:**
+- Create: `src/components/TutorialHands.ts`
+
+**Step 1: Define finger mapping**
+Map each key (QWERTY) to one of 10 fingers.
+
+**Step 2: Implement `highlightFinger(char)`**
+Render hand outlines and highlight the specific finger for the character.
+
+**Step 3: Commit**
+```bash
+git add src/components/TutorialHands.ts
+git commit -m "feat: add TutorialHands component"
+```
+
+---
+
+### Task 4: Integrate TutorialHands into Scenes
+
+**Files:**
+- Modify: `src/scenes/level-types/GoblinWhackerLevel.ts` (and others as needed)
+- Modify: `src/scenes/CutsceneScene.ts`
+
+**Step 1: Add TutorialHands to w1_l1**
+Show hands during the character creator/intro levels.
+
+**Step 2: Add to CutsceneScene**
+Show hands during letter unlock animations.
+
+**Step 3: Commit**
+```bash
+git add src/scenes/level-types/ src/scenes/CutsceneScene.ts
+git commit -m "feat: integrate tutorial hands into intro and cutscenes"
+```
+
+---
+
+### Task 5: World Mastery Chests in OverlandMap
+
+**Files:**
+- Modify: `src/scenes/OverlandMapScene.ts`
+
+**Step 1: Calculate world completion**
+Add a "Mastery Chest" sprite/rectangle that only appears if `checkWorldMastery` returns true for that world.
+
+**Step 2: Award rare items**
+On click, award the world-specific mastery item (e.g., Speed Boots).
+
+**Step 3: Commit**
+```bash
+git add src/scenes/OverlandMapScene.ts
+git commit -m "feat: add World Mastery Chests to OverlandMap"
+```
+
+---
+
+### Task 6: Monster Manual Weakness Logic
+
+**Files:**
+- Modify: `src/scenes/level-types/MonsterManualLevel.ts`
+- Modify: `src/scenes/BossBattleScene.ts`
+
+**Step 1: Set weakness flag in MonsterManualLevel**
+On completion, set `profile.bossWeaknessKnown = currentWorldBossId`.
+
+**Step 2: Apply buff in Boss Battle**
+If flag matches, reduce boss health or slow boss timer.
+
+**Step 3: Commit**
+```bash
+git add src/scenes/level-types/MonsterManualLevel.ts src/scenes/BossBattleScene.ts
+git commit -m "feat: implement Monster Manual weakness buff"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Step 1: Verify all new systems**
+Play World 1, get 10 stars on all levels, check for Mastery Chest.
+Beat a boss without a companion, check for Solo Scribe title.
+Verify hands appear in World 1-1.
+
+**Step 2: Run tests**
+`npm test`

--- a/src/scenes/LevelResultScene.ts
+++ b/src/scenes/LevelResultScene.ts
@@ -3,7 +3,7 @@ import Phaser from 'phaser'
 import { ProfileData, LevelConfig } from '../types'
 import { loadProfile, saveProfile } from '../utils/profile'
 import { calcXpReward, calcCharacterLevel } from '../utils/scoring'
-import { getLevelsForWorld } from '../data/levels'
+import { getLevelsForWorld, ALL_LEVELS } from '../data/levels'
 import { ITEMS } from '../data/items'
 import { createCompanion } from '../data/companions'
 
@@ -13,6 +13,7 @@ interface ResultData {
   accuracyStars: number
   speedStars: number
   passed: boolean
+  companionUsed: boolean
   captureAttempt?: { monsterId: string; monsterName: string }
 }
 
@@ -43,25 +44,37 @@ export class LevelResultScene extends Phaser.Scene {
     this.profile.xp += xpGained
     this.profile.characterLevel = calcCharacterLevel(this.profile.xp)
 
-    // Save level result (only improve, never overwrite with worse)
+    // Save level result (only improve, never overwrite with worse total score)
     const prev = this.profile.levelResults[level.id]
-    if (!prev || accuracyStars + speedStars > prev.accuracyStars + prev.speedStars) {
+    const currentStars = accuracyStars + speedStars
+    const prevStars = prev ? prev.accuracyStars + prev.speedStars : -1
+
+    if (!prev || currentStars > prevStars) {
       this.profile.levelResults[level.id] = {
         accuracyStars: accuracyStars as any,
         speedStars: speedStars as any,
         completedAt: Date.now(),
+        companionUsed: this.resultData.companionUsed,
+      }
+    } else if (currentStars === prevStars) {
+      // If same score, but this run was solo and previous wasn't, prioritize the solo run
+      if (this.resultData.companionUsed === false && prev.companionUsed === true) {
+        this.profile.levelResults[level.id].companionUsed = false
       }
     }
 
     // Award items/spells/titles
-    if (level.rewards.item && !this.profile.equipment.weapon) {
-      // Simplified: give item to first empty slot
+    if (level.rewards.item && !this.profile.ownedItemIds.includes(level.rewards.item)) {
+      this.profile.ownedItemIds.push(level.rewards.item)
     }
     if (level.rewards.title) {
       if (!this.profile.titles.includes(level.rewards.title)) {
         this.profile.titles.push(level.rewards.title)
       }
     }
+
+    // Solo Scribe title check
+    this.checkSoloScribe()
 
     // Unlock next level(s)
     this.unlockNextLevels(level)
@@ -146,6 +159,13 @@ export class LevelResultScene extends Phaser.Scene {
       }).setOrigin(0.5)
     }
 
+    if (level.isBoss) {
+      const soloStatus = this.resultData.companionUsed ? '❌ Companion Used' : '✅ Solo'
+      this.add.text(width / 2, 420, `Solo Scribe Status: ${soloStatus}`, {
+        fontSize: '24px', color: this.resultData.companionUsed ? '#ff8888' : '#88ff88'
+      }).setOrigin(0.5)
+    }
+
     // Continue button
     const cont = this.add.text(width / 2, 640, '[ Continue ]', {
       fontSize: '32px', color: '#ffffff'
@@ -162,6 +182,21 @@ export class LevelResultScene extends Phaser.Scene {
         this.scene.start('OverlandMap', { profileSlot: this.resultData.profileSlot })
       }
     })
+  }
+
+  private checkSoloScribe() {
+    const bossLevelConfigs = ALL_LEVELS.filter(l => l.isBoss)
+    let allSolo = true
+    for (const config of bossLevelConfigs) {
+      const result = this.profile.levelResults[config.id]
+      if (!result || result.companionUsed !== false) {
+        allSolo = false
+        break
+      }
+    }
+    if (allSolo && !this.profile.titles.includes('Solo Scribe')) {
+      this.profile.titles.push('Solo Scribe')
+    }
   }
 
   private showFailScreen() {

--- a/src/scenes/boss-types/AncientDragonBoss.ts
+++ b/src/scenes/boss-types/AncientDragonBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/AncientDragonBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -220,6 +221,9 @@ export class AncientDragonBoss extends Phaser.Scene {
       ? { monsterId: 'ancient_dragon', monsterName: 'Ancient Dragon' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(2000, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -227,6 +231,7 @@ export class AncientDragonBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/BaronTypoBoss.ts
+++ b/src/scenes/boss-types/BaronTypoBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/BaronTypoBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -232,6 +233,9 @@ export class BaronTypoBoss extends Phaser.Scene {
       ? { monsterId: 'baron_typo', monsterName: 'Baron Typo' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -239,6 +243,7 @@ export class BaronTypoBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/BoneKnightBoss.ts
+++ b/src/scenes/boss-types/BoneKnightBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/BoneKnightBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -275,6 +276,9 @@ export class BoneKnightBoss extends Phaser.Scene {
             ? { monsterId: 'bone_knight', monsterName: 'Bone Knight' }
             : undefined
 
+        const profile = loadProfile(this.profileSlot)
+        const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
         this.time.delayedCall(2000, () => {
             this.scene.start('LevelResult', {
                 level: this.level,
@@ -282,6 +286,7 @@ export class BoneKnightBoss extends Phaser.Scene {
                 accuracyStars: acc,
                 speedStars: spd,
                 passed,
+                companionUsed,
                 captureAttempt,
             })
         })

--- a/src/scenes/boss-types/ClockworkDragonBoss.ts
+++ b/src/scenes/boss-types/ClockworkDragonBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/ClockworkDragonBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -348,6 +349,9 @@ export class ClockworkDragonBoss extends Phaser.Scene {
 
     const captureAttempt = this.level.captureEligible ? { monsterId: 'clockwork_dragon', monsterName: 'Clockwork Dragon' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -355,6 +359,7 @@ export class ClockworkDragonBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/DiceLichBoss.ts
+++ b/src/scenes/boss-types/DiceLichBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/DiceLichBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -309,6 +310,9 @@ export class DiceLichBoss extends Phaser.Scene {
       ? { monsterId: 'dice_lich', monsterName: 'Dice Lich' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(2000, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -316,6 +320,7 @@ export class DiceLichBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/FlashWordBoss.ts
+++ b/src/scenes/boss-types/FlashWordBoss.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -141,6 +142,9 @@ export class FlashWordBoss extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -148,6 +152,7 @@ export class FlashWordBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/GrizzlefangBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -215,6 +216,9 @@ export class GrizzlefangBoss extends Phaser.Scene {
       ? { monsterId: 'grizzlefang', monsterName: 'Grizzlefang' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => { // Longer delay for big boss
       this.scene.start('LevelResult', {
         level: this.level,
@@ -222,6 +226,7 @@ export class GrizzlefangBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/HydraBoss.ts
+++ b/src/scenes/boss-types/HydraBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/HydraBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -311,6 +312,9 @@ export class HydraBoss extends Phaser.Scene {
 
     const captureAttempt = this.level.captureEligible ? { monsterId: 'hydra', monsterName: 'Hydra' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -318,6 +322,7 @@ export class HydraBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/MiniBossTypical.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -175,6 +176,9 @@ export class MiniBossTypical extends Phaser.Scene {
       ? { monsterId: this.level.bossId || 'miniboss', monsterName: 'Mini-Boss' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1000, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -182,6 +186,7 @@ export class MiniBossTypical extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/SlimeKingBoss.ts
+++ b/src/scenes/boss-types/SlimeKingBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/SlimeKingBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -198,6 +199,9 @@ export class SlimeKingBoss extends Phaser.Scene {
       ? { monsterId: 'slime_king', monsterName: 'Slime King' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -205,6 +209,7 @@ export class SlimeKingBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/boss-types/SpiderBoss.ts
+++ b/src/scenes/boss-types/SpiderBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/SpiderBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -330,6 +331,9 @@ export class SpiderBoss extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(1500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -337,6 +341,7 @@ export class SpiderBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt: passed && this.level.captureEligible ? { monsterId: 'spider', monsterName: 'Web Spinner' } : undefined
       })
     })

--- a/src/scenes/boss-types/TypemancerBoss.ts
+++ b/src/scenes/boss-types/TypemancerBoss.ts
@@ -1,6 +1,7 @@
 // src/scenes/boss-types/TypemancerBoss.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
+import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
@@ -277,6 +278,9 @@ export class TypemancerBoss extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(2000, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -284,6 +288,7 @@ export class TypemancerBoss extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/DungeonEscapeLevel.ts
+++ b/src/scenes/level-types/DungeonEscapeLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -119,6 +120,9 @@ export class DungeonEscapeLevel extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -126,6 +130,7 @@ export class DungeonEscapeLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/DungeonTrapDisarmLevel.ts
+++ b/src/scenes/level-types/DungeonTrapDisarmLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -208,6 +209,9 @@ export class DungeonTrapDisarmLevel extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -215,6 +219,7 @@ export class DungeonTrapDisarmLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/GoblinWhackerLevel.ts
+++ b/src/scenes/level-types/GoblinWhackerLevel.ts
@@ -230,6 +230,9 @@ export class GoblinWhackerLevel extends Phaser.Scene {
       ? { monsterId: 'goblin', monsterName: 'Goblin' }
       : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -237,6 +240,7 @@ export class GoblinWhackerLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
         captureAttempt,
       })
     })

--- a/src/scenes/level-types/GuildRecruitmentLevel.ts
+++ b/src/scenes/level-types/GuildRecruitmentLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -101,6 +102,9 @@ export class GuildRecruitmentLevel extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -108,6 +112,7 @@ export class GuildRecruitmentLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/MagicRuneTypingLevel.ts
+++ b/src/scenes/level-types/MagicRuneTypingLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -124,6 +125,9 @@ export class MagicRuneTypingLevel extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -131,6 +135,7 @@ export class MagicRuneTypingLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/MonsterArenaLevel.ts
+++ b/src/scenes/level-types/MonsterArenaLevel.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -154,10 +155,14 @@ export class MonsterArenaLevel extends Phaser.Scene {
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
     const captureAttempt = this.level.captureEligible ? { monsterId: 'boss', monsterName: 'Arena Boss' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level, profileSlot: this.profileSlot,
-        accuracyStars: acc, speedStars: spd, passed, captureAttempt
+        accuracyStars: acc, speedStars: spd, passed, 
+        companionUsed, captureAttempt
       })
     })
   }

--- a/src/scenes/level-types/MonsterManualLevel.ts
+++ b/src/scenes/level-types/MonsterManualLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 
 export class MonsterManualLevel extends Phaser.Scene {
@@ -76,6 +77,9 @@ export class MonsterManualLevel extends Phaser.Scene {
     this.finished = true
     this.engine.destroy()
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     // No star pressure for MonsterManual
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
@@ -84,6 +88,7 @@ export class MonsterManualLevel extends Phaser.Scene {
         accuracyStars: 5,
         speedStars: 5,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/PotionBrewingLabLevel.ts
+++ b/src/scenes/level-types/PotionBrewingLabLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -126,6 +127,9 @@ export class PotionBrewingLabLevel extends Phaser.Scene {
     const acc = calcAccuracyStars(this.engine.correctKeystrokes, this.engine.totalKeystrokes)
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level,
@@ -133,6 +137,7 @@ export class PotionBrewingLabLevel extends Phaser.Scene {
         accuracyStars: acc,
         speedStars: spd,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/SillyChallengeLevel.ts
+++ b/src/scenes/level-types/SillyChallengeLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 
 interface SillyEntity {
@@ -176,6 +177,9 @@ export class SillyChallengeLevel extends Phaser.Scene {
     this.spawnTimer?.remove()
     this.engine.destroy()
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     // SillyChallenge always gives max stars for base XP
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
@@ -184,6 +188,7 @@ export class SillyChallengeLevel extends Phaser.Scene {
         accuracyStars: 5,
         speedStars: 5,
         passed,
+        companionUsed,
       })
     })
   }

--- a/src/scenes/level-types/SkeletonSwarmLevel.ts
+++ b/src/scenes/level-types/SkeletonSwarmLevel.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -153,10 +154,14 @@ export class SkeletonSwarmLevel extends Phaser.Scene {
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
     const captureAttempt = this.level.captureEligible ? { monsterId: 'skeleton', monsterName: 'Skeleton' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level, profileSlot: this.profileSlot,
-        accuracyStars: acc, speedStars: spd, passed, captureAttempt
+        accuracyStars: acc, speedStars: spd, passed, 
+        companionUsed, captureAttempt
       })
     })
   }

--- a/src/scenes/level-types/SlimeSplittingLevel.ts
+++ b/src/scenes/level-types/SlimeSplittingLevel.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -151,10 +152,14 @@ export class SlimeSplittingLevel extends Phaser.Scene {
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
     const captureAttempt = this.level.captureEligible ? { monsterId: 'slime', monsterName: 'Slime' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level, profileSlot: this.profileSlot,
-        accuracyStars: acc, speedStars: spd, passed, captureAttempt
+        accuracyStars: acc, speedStars: spd, passed, 
+        companionUsed, captureAttempt
       })
     })
   }

--- a/src/scenes/level-types/UndeadSiegeLevel.ts
+++ b/src/scenes/level-types/UndeadSiegeLevel.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 
@@ -154,10 +155,14 @@ export class UndeadSiegeLevel extends Phaser.Scene {
     const spd = calcSpeedStars(Math.round(this.engine.completedWords / (elapsed / 60000)), this.level.world)
     const captureAttempt = this.level.captureEligible ? { monsterId: 'undead', monsterName: 'Undead' } : undefined
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     this.time.delayedCall(500, () => {
       this.scene.start('LevelResult', {
         level: this.level, profileSlot: this.profileSlot,
-        accuracyStars: acc, speedStars: spd, passed, captureAttempt
+        accuracyStars: acc, speedStars: spd, passed, 
+        companionUsed, captureAttempt
       })
     })
   }

--- a/src/scenes/level-types/WoodlandFestivalLevel.ts
+++ b/src/scenes/level-types/WoodlandFestivalLevel.ts
@@ -2,6 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
+import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 
 export class WoodlandFestivalLevel extends Phaser.Scene {
@@ -99,6 +100,9 @@ export class WoodlandFestivalLevel extends Phaser.Scene {
     this.engine.destroy()
     this.aiTimer?.remove()
 
+    const profile = loadProfile(this.profileSlot)
+    const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
     // WoodlandFestival has no fail state, max stars for base XP
     this.time.delayedCall(1000, () => {
       this.scene.start('LevelResult', {
@@ -107,6 +111,7 @@ export class WoodlandFestivalLevel extends Phaser.Scene {
         accuracyStars: 5,
         speedStars: 5,
         passed,
+        companionUsed,
       })
     })
   }


### PR DESCRIPTION
## Summary
- Updated `ResultData` and `LevelResult` to track `companionUsed`.
- Updated all level and boss scenes to pass `companionUsed` status.
- Implemented "Solo Scribe" achievement logic in `LevelResultScene`.
- Added Solo Scribe status display for boss levels.