### PR TITLE
feat: Monster Manual weakness buff for boss battles

### DIFF
--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -31,6 +31,7 @@ export class GrizzlefangBoss extends Phaser.Scene {
   private timerEvent?: Phaser.Time.TimerEvent
   private attackTimer?: Phaser.Time.TimerEvent
   private finished = false
+  private weaknessActive = false
 
   constructor() { super('GrizzlefangBoss') }
 
@@ -42,6 +43,9 @@ export class GrizzlefangBoss extends Phaser.Scene {
     this.phase = 1
     // Number of words is dictated by config, let's distribute evenly across 3 phases
     this.wordsPerPhase = Math.max(1, Math.ceil(this.level.wordCount / this.maxPhases))
+    // Check if player has studied the Monster Manual for this boss
+    const profile = loadProfile(data.profileSlot)
+    this.weaknessActive = profile?.bossWeaknessKnown === (data.level.bossId ?? '')
   }
 
   create() {
@@ -70,8 +74,15 @@ export class GrizzlefangBoss extends Phaser.Scene {
     // Boss Sprite (Grizzlefang is big and orange/brown)
     this.bossSprite = this.add.rectangle(width / 2, height / 2 - 50, 300, 300, 0x8b4513)
     
-    this.bossMaxHp = this.level.wordCount
+    this.bossMaxHp = this.weaknessActive
+      ? Math.max(1, Math.floor(this.level.wordCount * 0.8))
+      : this.level.wordCount
     this.bossHp = this.bossMaxHp
+    if (this.weaknessActive) {
+      this.add.text(width / 2, 90, '⚡ Weakness Known! Boss HP -20%', {
+        fontSize: '18px', color: '#aaffaa'
+      }).setOrigin(0.5)
+    }
     this.bossHpText = this.add.text(width / 2, height / 2 - 220, `Grizzlefang HP: ${this.bossHp}/${this.bossMaxHp}`, {
       fontSize: '24px', color: '#ff8800'
     }).setOrigin(0.5)

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -25,6 +25,7 @@ export class MiniBossTypical extends Phaser.Scene {
   private timerEvent?: Phaser.Time.TimerEvent
   private attackTimer?: Phaser.Time.TimerEvent
   private finished = false
+  private weaknessActive = false
 
   constructor() { super('MiniBossTypical') }
 
@@ -33,6 +34,8 @@ export class MiniBossTypical extends Phaser.Scene {
     this.profileSlot = data.profileSlot
     this.finished = false
     this.playerHp = 3
+    const profile = loadProfile(data.profileSlot)
+    this.weaknessActive = profile?.bossWeaknessKnown === (data.level.bossId ?? '')
   }
 
   create() {
@@ -58,11 +61,21 @@ export class MiniBossTypical extends Phaser.Scene {
     const difficulty = Math.ceil(this.level.world / 2)
     this.words = getWordPool(this.level.unlockedLetters, this.level.wordCount, difficulty)
     this.wordQueue = [...this.words]
-    this.bossMaxHp = this.wordQueue.length
+    const rawHp = this.wordQueue.length
+    this.bossMaxHp = this.weaknessActive ? Math.max(1, Math.floor(rawHp * 0.8)) : rawHp
     this.bossHp = this.bossMaxHp
+    // Trim word queue to match reduced HP
+    if (this.weaknessActive) {
+      this.wordQueue = this.wordQueue.slice(0, this.bossMaxHp)
+    }
 
     // Boss Sprite
     this.bossSprite = this.add.rectangle(width / 2, height / 2 - 50, 200, 200, 0xaa4444)
+    if (this.weaknessActive) {
+      this.add.text(width / 2, 55, '⚡ Weakness Known! Boss HP -20%', {
+        fontSize: '16px', color: '#aaffaa'
+      }).setOrigin(0.5)
+    }
     this.bossHpText = this.add.text(width / 2, height / 2 - 180, `Boss HP: ${this.bossHp}/${this.bossMaxHp}`, {
       fontSize: '24px', color: '#ffffff'
     }).setOrigin(0.5)

--- a/src/scenes/level-types/MonsterManualLevel.ts
+++ b/src/scenes/level-types/MonsterManualLevel.ts
@@ -2,7 +2,7 @@
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'
 import { TypingEngine } from '../../components/TypingEngine'
-import { loadProfile } from '../../utils/profile'
+import { loadProfile, saveProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 
 export class MonsterManualLevel extends Phaser.Scene {
@@ -79,6 +79,19 @@ export class MonsterManualLevel extends Phaser.Scene {
 
     const profile = loadProfile(this.profileSlot)
     const companionUsed = !!(profile?.activeCompanionId || profile?.activePetId)
+
+    // Record that the player has learned the boss weakness for this world
+    if (profile && passed) {
+      const worldBossMap: Record<number, string> = {
+        1: 'grizzlefang',
+        2: 'hydra',
+        3: 'clockwork_dragon',
+        4: 'badrang',
+        5: 'typemancer',
+      }
+      profile.bossWeaknessKnown = worldBossMap[this.level.world] ?? null
+      saveProfile(this.profileSlot, profile)
+    }
 
     // No star pressure for MonsterManual
     this.time.delayedCall(500, () => {


### PR DESCRIPTION
## Summary
- MonsterManualLevel now saves \`bossWeaknessKnown\` to the player profile upon completion, mapping the current world to its final boss
- GrizzlefangBoss and MiniBossTypical check the weakness flag and apply a 20% HP reduction if the player studied the Monster Manual
- Shows a "⚡ Weakness Known! Boss HP -20%" indicator when the buff is active

## Task Completed
- Task 6: Monster Manual Weakness Logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)