### PR TITLE
Add gold system: earn gold per enemy, spend to recruit heroes

### DIFF
--- a/src/data/companions.ts
+++ b/src/data/companions.ts
@@ -1,10 +1,14 @@
 import { CompanionData } from '../types'
 
-export const COMPANION_TEMPLATES: Omit<CompanionData, 'level' | 'xp' | 'autoStrikeCount'>[] = [
-  { id: 'mouse_guard_scout', name: 'Pip the Mouse Guard Scout', backstory: 'A brave mouse who patrols the forest paths.', type: 'companion' },
-  { id: 'badger_warrior', name: 'Brom the Badger Warrior', backstory: 'Fierce protector of the woodland creatures.', type: 'companion' },
-  { id: 'wizard_apprentice', name: 'Elara the Apprentice', backstory: 'Studying magic at the Wizard Peaks.', type: 'companion' },
-  { id: 'archer', name: 'Swift the Forest Archer', backstory: 'Never misses a shot.', type: 'companion' },
+export interface CompanionTemplate extends Omit<CompanionData, 'level' | 'xp' | 'autoStrikeCount'> {
+  goldCost: number
+}
+
+export const COMPANION_TEMPLATES: CompanionTemplate[] = [
+  { id: 'mouse_guard_scout', name: 'Pip the Mouse Guard Scout', backstory: 'A brave mouse who patrols the forest paths.', type: 'companion', goldCost: 50 },
+  { id: 'badger_warrior', name: 'Brom the Badger Warrior', backstory: 'Fierce protector of the woodland creatures.', type: 'companion', goldCost: 100 },
+  { id: 'wizard_apprentice', name: 'Elara the Apprentice', backstory: 'Studying magic at the Wizard Peaks.', type: 'companion', goldCost: 150 },
+  { id: 'archer', name: 'Swift the Forest Archer', backstory: 'Never misses a shot.', type: 'companion', goldCost: 200 },
 ]
 
 export const PET_TEMPLATES: Omit<CompanionData, 'level' | 'xp' | 'autoStrikeCount'>[] = [

--- a/src/scenes/LevelResultScene.ts
+++ b/src/scenes/LevelResultScene.ts
@@ -44,6 +44,10 @@ export class LevelResultScene extends Phaser.Scene {
     this.profile.xp += xpGained
     this.profile.characterLevel = calcCharacterLevel(this.profile.xp)
 
+    // Award gold — 2 gold per enemy (word) defeated
+    const goldEarned = level.wordCount * 2
+    this.profile.gold = (this.profile.gold ?? 0) + goldEarned
+
     // Save level result (only improve, never overwrite with worse total score)
     const prev = this.profile.levelResults[level.id]
     const currentStars = accuracyStars + speedStars
@@ -146,22 +150,26 @@ export class LevelResultScene extends Phaser.Scene {
       fontSize: '28px', color: '#aaffaa'
     }).setOrigin(0.5)
 
+    this.add.text(width / 2, 415, `+${goldEarned} Gold`, {
+      fontSize: '24px', color: '#ffd700'
+    }).setOrigin(0.5)
+
     if (this.profile.characterLevel > prevLevel) {
-      this.add.text(width / 2, 420, `Level Up! Now Level ${this.profile.characterLevel}`, {
+      this.add.text(width / 2, 455, `Level Up! Now Level ${this.profile.characterLevel}`, {
         fontSize: '24px', color: '#ffd700'
       }).setOrigin(0.5)
     }
 
     // Letter unlock banner
     if (level.miniBossUnlocksLetter) {
-      this.add.text(width / 2, 470, `The letter "${level.miniBossUnlocksLetter.toUpperCase()}" has been restored!`, {
+      this.add.text(width / 2, 500, `The letter "${level.miniBossUnlocksLetter.toUpperCase()}" has been restored!`, {
         fontSize: '26px', color: '#aaaaff'
       }).setOrigin(0.5)
     }
 
     if (level.isBoss) {
       const soloStatus = this.resultData.companionUsed ? '❌ Companion Used' : '✅ Solo'
-      this.add.text(width / 2, 420, `Solo Scribe Status: ${soloStatus}`, {
+      this.add.text(width / 2, 455, `Solo Scribe Status: ${soloStatus}`, {
         fontSize: '24px', color: this.resultData.companionUsed ? '#ff8888' : '#88ff88'
       }).setOrigin(0.5)
     }

--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -75,6 +75,10 @@ export class OverlandMapScene extends Phaser.Scene {
       fontSize: '20px', color: '#ffffff'
     })
 
+    this.add.text(width - 20, 20, `Gold: ${this.profile.gold ?? 0}`, {
+      fontSize: '20px', color: '#ffd700'
+    }).setOrigin(1, 0)
+
     // World navigation arrows
     this.drawWorldArrows()
 

--- a/src/scenes/TavernScene.ts
+++ b/src/scenes/TavernScene.ts
@@ -43,22 +43,33 @@ export class TavernScene extends Phaser.Scene {
       })
     }
 
-    this.add.text(width / 2, height - 200, 'Available to Recruit:', {
+    this.add.text(width / 2, height - 220, 'Available to Recruit:', {
       fontSize: '20px', color: '#aaaaff'
     }).setOrigin(0.5)
+
+    this.add.text(width - 20, 20, `Gold: ${this.profile.gold ?? 0}`, {
+      fontSize: '20px', color: '#ffd700'
+    }).setOrigin(1, 0)
 
     const available = COMPANION_TEMPLATES.filter(
       t => !this.profile.companions.find(c => c.id === t.id)
     )
     available.slice(0, 3).forEach((t, i) => {
       const cx = 200 + i * 300
-      const cy = height - 130
-      const card = this.add.rectangle(cx, cy, 260, 80, 0x333366)
+      const cy = height - 140
+      const canAfford = (this.profile.gold ?? 0) >= t.goldCost
+      const card = this.add.rectangle(cx, cy, 260, 90, canAfford ? 0x333366 : 0x2a2a2a)
         .setInteractive({ useHandCursor: true })
-      this.add.text(cx, cy - 15, t.name, { fontSize: '14px', color: '#ffffff' }).setOrigin(0.5)
-      this.add.text(cx, cy + 10, '[ Recruit ]', { fontSize: '14px', color: '#aaaaff' }).setOrigin(0.5)
+      this.add.text(cx, cy - 25, t.name, { fontSize: '14px', color: '#ffffff' }).setOrigin(0.5)
+      this.add.text(cx, cy, `Cost: ${t.goldCost} Gold`, {
+        fontSize: '13px', color: canAfford ? '#ffd700' : '#886600'
+      }).setOrigin(0.5)
+      this.add.text(cx, cy + 22, canAfford ? '[ Recruit ]' : '[ Not enough gold ]', {
+        fontSize: '13px', color: canAfford ? '#aaaaff' : '#666666'
+      }).setOrigin(0.5)
       card.on('pointerdown', () => {
-        if (!this.profile.companions.find(c => c.id === t.id)) {
+        if (!this.profile.companions.find(c => c.id === t.id) && (this.profile.gold ?? 0) >= t.goldCost) {
+          this.profile.gold -= t.goldCost
           this.profile.companions.push(createCompanion(t.id))
           saveProfile(this.profileSlot, this.profile)
           this.scene.restart({ profileSlot: this.profileSlot })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,6 +48,7 @@ export interface ProfileData {
   worldMasteryRewards: string[]
   bossWeaknessKnown: string | null
   gameMode: 'regular' | 'advanced'
+  gold: number
 }
 
 export type LevelType =

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -29,6 +29,7 @@ export function createProfile(playerName: string, avatarChoice = 'knight'): Prof
     worldMasteryRewards: [],
     bossWeaknessKnown: null,
     gameMode: 'regular' as const,
+    gold: 0,
   }
 }
 
@@ -42,6 +43,7 @@ export function loadProfile(slot: number): ProfileData | null {
   try {
     const data = JSON.parse(raw) as ProfileData
     if (!data.gameMode) data.gameMode = 'regular'
+    if (data.gold === undefined) data.gold = 0
     return data
   } catch {
     return null


### PR DESCRIPTION
- Add `gold: number` to ProfileData (starts at 0, migrated on load)
- Award 2 gold per enemy defeated (wordCount * 2) on level completion
- Show gold earned on the LevelResult victory screen
- Add goldCost to each COMPANION_TEMPLATES entry (50/100/150/200 gold)
- TavernScene: display gold balance, show costs, block/deduct on recruit
- OverlandMapScene: display gold balance in top-right corner

https://claude.ai/code/session_01E4awigsxTxK66GqTHJBCQ6