### PR TITLE
feat: update miniboss behavior in regular mode

### DIFF
--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -32,6 +32,9 @@ export class GrizzlefangBoss extends Phaser.Scene {
   private attackTimer?: Phaser.Time.TimerEvent
   private finished = false
   private weaknessActive = false
+  private gameMode: 'regular' | 'advanced' = 'regular'
+  private wrongKeyCount = 0
+  private nextAttackThreshold = 0
 
   constructor() { super('GrizzlefangBoss') }
 
@@ -46,6 +49,9 @@ export class GrizzlefangBoss extends Phaser.Scene {
     // Check if player has studied the Monster Manual for this boss
     const profile = loadProfile(data.profileSlot)
     this.weaknessActive = profile?.bossWeaknessKnown === (data.level.bossId ?? '')
+    this.gameMode = profile?.gameMode ?? 'regular'
+    this.wrongKeyCount = 0
+    this.nextAttackThreshold = Phaser.Math.Between(2, 5)
   }
 
   create() {
@@ -132,12 +138,14 @@ export class GrizzlefangBoss extends Phaser.Scene {
     
     // Setup attack timer based on phase
     this.attackTimer?.remove()
-    this.attackTimer = this.time.addEvent({
-      delay: Math.max(1500, 4000 - (this.phase * 500)), // Gets faster each phase
-      loop: true,
-      callback: this.bossAttack,
-      callbackScope: this
-    })
+    if (this.gameMode === 'advanced') {
+      this.attackTimer = this.time.addEvent({
+        delay: Math.max(1500, 4000 - (this.phase * 500)), // Gets faster each phase
+        loop: true,
+        callback: this.bossAttack,
+        callbackScope: this
+      })
+    }
     
     // Visual cue for phase change
     this.cameras.main.flash(500, 255, 136, 0)
@@ -204,6 +212,15 @@ export class GrizzlefangBoss extends Phaser.Scene {
 
   private onWrongKey() {
     this.cameras.main.flash(80, 120, 0, 0)
+
+    if (this.gameMode === 'regular' && !this.finished) {
+      this.wrongKeyCount++
+      if (this.wrongKeyCount >= this.nextAttackThreshold) {
+        this.wrongKeyCount = 0
+        this.nextAttackThreshold = Phaser.Math.Between(2, 5)
+        this.bossAttack()
+      }
+    }
   }
 
   private endLevel(passed: boolean) {

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -26,6 +26,9 @@ export class MiniBossTypical extends Phaser.Scene {
   private attackTimer?: Phaser.Time.TimerEvent
   private finished = false
   private weaknessActive = false
+  private gameMode: 'regular' | 'advanced' = 'regular'
+  private wrongKeyCount = 0
+  private nextAttackThreshold = 0
 
   constructor() { super('MiniBossTypical') }
 
@@ -36,6 +39,9 @@ export class MiniBossTypical extends Phaser.Scene {
     this.playerHp = 3
     const profile = loadProfile(data.profileSlot)
     this.weaknessActive = profile?.bossWeaknessKnown === (data.level.bossId ?? '')
+    this.gameMode = profile?.gameMode ?? 'regular'
+    this.wrongKeyCount = 0
+    this.nextAttackThreshold = Phaser.Math.Between(2, 5)
   }
 
   create() {
@@ -109,12 +115,14 @@ export class MiniBossTypical extends Phaser.Scene {
     }
 
     // Boss Attack Timer (Attacks every X seconds if not defeated)
-    this.attackTimer = this.time.addEvent({
-      delay: 5000 - (this.level.world * 200), // Faster in later worlds
-      loop: true,
-      callback: this.bossAttack,
-      callbackScope: this
-    })
+    if (this.gameMode === 'advanced') {
+      this.attackTimer = this.time.addEvent({
+        delay: 5000 - (this.level.world * 200), // Faster in later worlds
+        loop: true,
+        callback: this.bossAttack,
+        callbackScope: this
+      })
+    }
 
     this.loadNextWord()
   }
@@ -166,6 +174,15 @@ export class MiniBossTypical extends Phaser.Scene {
 
   private onWrongKey() {
     this.cameras.main.flash(80, 120, 0, 0)
+
+    if (this.gameMode === 'regular' && !this.finished) {
+      this.wrongKeyCount++
+      if (this.wrongKeyCount >= this.nextAttackThreshold) {
+        this.wrongKeyCount = 0
+        this.nextAttackThreshold = Phaser.Math.Between(2, 5)
+        this.bossAttack()
+      }
+    }
   }
 
   private endLevel(passed: boolean) {


### PR DESCRIPTION
This PR addresses the issue where the ogre miniboss behaved the same in both regular and advanced profile modes. Based on user feedback, the behavior in `regular` mode has been updated to trigger an attack randomly every 2 to 5 missed keystrokes instead of using a time-based attack (which is kept for `advanced` mode).

Changes applied to `MiniBossTypical` and `GrizzlefangBoss` (which covers both the miniboss and the final world boss for consistency).

---
*PR created automatically by Jules for task [12612524857306601688](https://jules.google.com/task/12612524857306601688) started by @flamableconcrete*