### PR TITLE
Fix typing hands overlay mirroring and thumb size

### DIFF
--- a/src/components/TutorialHands.ts
+++ b/src/components/TutorialHands.ts
@@ -59,7 +59,8 @@ export class TutorialHands {
 
     leftFingers.forEach(([f, label], i) => {
       const x = this.cx - totalW - 20 + i * (fw + gap)
-      const rect = this.scene.add.rectangle(x, this.cy, fw, fh, 0x334466)
+      const h = f === 'lt' ? fh / 2 : fh
+      const rect = this.scene.add.rectangle(x, this.cy, fw, h, 0x334466)
       const text = this.scene.add.text(x, this.cy, label, {
         fontSize: '12px', color: '#aaaacc'
       }).setOrigin(0.5)
@@ -69,7 +70,8 @@ export class TutorialHands {
 
     rightFingers.forEach(([f, label], i) => {
       const x = this.cx + 20 + i * (fw + gap)
-      const rect = this.scene.add.rectangle(x, this.cy, fw, fh, 0x334466)
+      const h = f === 'rt' ? fh / 2 : fh
+      const rect = this.scene.add.rectangle(x, this.cy, fw, h, 0x334466)
       const text = this.scene.add.text(x, this.cy, label, {
         fontSize: '12px', color: '#aaaacc'
       }).setOrigin(0.5)

--- a/src/components/TypingHands.ts
+++ b/src/components/TypingHands.ts
@@ -108,29 +108,30 @@ export class TypingHands {
   }
 
   private buildHands(cx: number, cy: number) {
-    const fingerHeights = [50, 65, 75, 65, 45] // pinky, ring, middle, index, thumb
+    const leftFingerHeights = [50, 65, 75, 65, 20] // pinky, ring, middle, index, thumb
+    const rightFingerHeights = [20, 65, 75, 65, 50] // thumb, index, middle, ring, pinky
     const fw = 28
     const gap = 5
     const handWidth = 5 * fw + 4 * gap
     const handGap = 30
 
     const leftFingers: Finger[] = ['lp', 'lr', 'lm', 'li', 'lt']
-    const rightFingers: Finger[] = ['rp', 'rr', 'rm', 'ri', 'rt']
+    const rightFingers: Finger[] = ['rt', 'ri', 'rm', 'rr', 'rp']
 
     // Left hand
     const leftStartX = cx - handGap / 2 - handWidth
     leftFingers.forEach((finger, i) => {
       const x = leftStartX + i * (fw + gap)
-      const h = fingerHeights[i]
+      const h = leftFingerHeights[i]
       const y = cy - h / 2 + 20
       this.drawFinger(x, y, fw, h, finger)
     })
 
-    // Right hand (mirrored heights)
+    // Right hand
     const rightStartX = cx + handGap / 2
     rightFingers.forEach((finger, i) => {
       const x = rightStartX + i * (fw + gap)
-      const h = fingerHeights[4 - i]
+      const h = rightFingerHeights[i]
       const y = cy - h / 2 + 20
       this.drawFinger(x, y, fw, h, finger)
     })


### PR DESCRIPTION
Fixes the finger hints overlay so that the right hand's fingers are ordered correctly and not mirrored, and the thumbs on both hands (and the tutorial overlay) are correctly sized smaller.

---
*PR created automatically by Jules for task [1161841855070750563](https://jules.google.com/task/1161841855070750563) started by @flamableconcrete*