### PR TITLE
Render player avatar on overworld map

### DIFF
--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -118,7 +118,11 @@ export class OverlandMapScene extends Phaser.Scene {
     // Drop shadow beneath avatar
     this.avatarShadow = this.add.ellipse(startPos.x, startPos.y + 2, 16, 6, 0x000000, 0.25)
       .setDepth(999)
-    this.avatar = this.add.sprite(startPos.x, startPos.y, 'avatar').setDepth(1000)
+
+    const avatarTexture = this.profile.avatarChoice || 'avatar_0'
+    this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(1000)
+    // Scale down the pixel art avatar slightly to fit the map nodes better
+    this.avatar.setScale(0.75)
   }
 
   private drawWorldArrows() {


### PR DESCRIPTION
Fixes the issue where the player was represented by a white dot on the overworld map by using their selected avatar instead.

---
*PR created automatically by Jules for task [518404507457247273](https://jules.google.com/task/518404507457247273) started by @flamableconcrete*