### PR TITLE
Fix: Remove stray fence asset in World 1

### DIFF
--- a/src/data/maps/world1.ts
+++ b/src/data/maps/world1.ts
@@ -279,7 +279,6 @@ function buildDecorations(): DecorationPlacement[] {
   decs.push({ tileIndex: FENCE, x: 102, y: 550 })
   decs.push({ tileIndex: FENCE, x: 134, y: 550 })
   decs.push({ tileIndex: FENCE, x: 166, y: 550 })
-  decs.push({ tileIndex: FENCE, x: 198, y: 550 })
 
   // Cottages — starting village
   decs.push({


### PR DESCRIPTION
Removed the last fence decoration (at x: 198, y: 550) from the starting village in `src/data/maps/world1.ts` as it was visually encroaching on the path between level 1 and level 2.

---
*PR created automatically by Jules for task [13362528650663531131](https://jules.google.com/task/13362528650663531131) started by @flamableconcrete*