### PR TITLE
Update finger hints layout and add to mini-boss levels

### DIFF
--- a/src/components/TypingHands.ts
+++ b/src/components/TypingHands.ts
@@ -85,11 +85,11 @@ export class TypingHands {
   }
 
   private buildNextLetterDisplay(cx: number, cy: number) {
-    const letterY = cy - 100
+    const letterY = cy
 
     this.nextLetterBg = this.scene.add.graphics()
     this.nextLetterBg.fillStyle(0x000000, 0.6)
-    this.nextLetterBg.fillCircle(cx, letterY, 36)
+    this.nextLetterBg.fillCircle(cx, letterY, 48)
     this.allObjects.push(this.nextLetterBg)
 
     this.nextLetterText = this.scene.add.text(cx, letterY, '', {
@@ -113,7 +113,7 @@ export class TypingHands {
     const fw = 28
     const gap = 5
     const handWidth = 5 * fw + 4 * gap
-    const handGap = 30
+    const handGap = 200
 
     const leftFingers: Finger[] = ['lp', 'lr', 'lm', 'li', 'lt']
     const rightFingers: Finger[] = ['rt', 'ri', 'rm', 'rr', 'rp']

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -5,6 +5,7 @@ import { loadProfile } from '../../utils/profile'
 import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
+import { TypingHands } from '../../components/TypingHands'
 import { generateGoblinWhackerTextures } from '../../art/goblinWhackerArt'
 import { setupPause } from '../../utils/pauseSetup'
 
@@ -31,6 +32,7 @@ export class MiniBossTypical extends Phaser.Scene {
   private gameMode: 'regular' | 'advanced' = 'regular'
   private wrongKeyCount = 0
   private nextAttackThreshold = 0
+  private typingHands?: TypingHands
 
   constructor() { super('MiniBossTypical') }
 
@@ -103,10 +105,25 @@ export class MiniBossTypical extends Phaser.Scene {
     this.engine = new TypingEngine({
       scene: this,
       x: width / 2,
-      y: height - 100,
+      y: height - 120,
       fontSize: 48,
       onWordComplete: this.onWordComplete.bind(this),
       onWrongKey: this.onWrongKey.bind(this),
+    })
+
+    // Typing hands overlay (player setting)
+    const profile = loadProfile(this.profileSlot)
+    if (profile?.showFingerHints) {
+      this.typingHands = new TypingHands(this, width / 2, height - 50)
+    }
+
+    this.input.keyboard?.on('keydown', () => {
+      if (this.wordQueue.length > 0 && this.typingHands) {
+        const word = this.wordQueue[0]
+        const nextIdx = this.engine.getTypedSoFar().length
+        const nextCh = word[nextIdx]
+        if (nextCh) this.typingHands.highlightFinger(nextCh)
+      }
     })
 
     // Timer
@@ -143,6 +160,9 @@ export class MiniBossTypical extends Phaser.Scene {
     const word = this.wordQueue[0]
     this.bossLabel.setText(word)
     this.engine.setWord(word)
+    if (this.typingHands && word[0]) {
+      this.typingHands.highlightFinger(word[0])
+    }
   }
 
   private bossAttack() {
@@ -205,6 +225,7 @@ export class MiniBossTypical extends Phaser.Scene {
     this.finished = true
     this.timerEvent?.remove()
     this.attackTimer?.remove()
+    this.typingHands?.fadeOut()
     this.engine.destroy()
 
     if (passed) {


### PR DESCRIPTION
- Increased `handGap` in `TypingHands.ts` to separate the hands.
- Moved the `letterY` position in `TypingHands.ts` to be vertically centered between the hands.
- Updated `MiniBossTypical.ts` to conditionally render `TypingHands` based on the user's profile settings.
- Added keydown event listeners in `MiniBossTypical.ts` to update the highlighted finger as the player types.
- Ensured `TypingHands` fades out when the mini-boss level ends.

---
*PR created automatically by Jules for task [15666787481129752461](https://jules.google.com/task/15666787481129752461) started by @flamableconcrete*