### PR TITLE
Fix missing ogre art for 'Knuckle the Ogre' mini boss

### DIFF
--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -79,7 +79,11 @@ export class MiniBossTypical extends Phaser.Scene {
     }
 
     // Boss Sprite
-    if (this.level.name.toLowerCase().includes('ogre') || this.level.bossId?.toLowerCase().includes('ogre')) {
+    const isOgre = this.level.name.toLowerCase().includes('ogre') ||
+                   this.level.bossId?.toLowerCase().includes('ogre') ||
+                   this.level.storyBeat?.toLowerCase().includes('ogre');
+
+    if (isOgre) {
       generateGoblinWhackerTextures(this)
       this.bossSprite = this.add.image(width / 2, height / 2 - 50, 'ogre').setScale(2)
     } else {


### PR DESCRIPTION
Fix missing ogre art for 'Knuckle the Ogre' mini boss

The `MiniBossTypical` scene checked if `this.level.name` or `this.level.bossId` contained 'ogre' to display the custom ogre art instead of a rectangle. However, 'Knuckle the Ogre, Keeper of E' had the name 'Flask Hollow' and the bossId 'knuckle_keeper_of_e', meaning neither matched.

This commit updates the check to also look for 'ogre' in `this.level.storyBeat`, ensuring the ogre art is correctly loaded and displayed for this boss.

---
*PR created automatically by Jules for task [13104436567382732735](https://jules.google.com/task/13104436567382732735) started by @flamableconcrete*