### PR TITLE
fix: clear scene state on init and add getWordPool fallback

### DIFF
--- a/src/scenes/boss-types/BoneKnightBoss.ts
+++ b/src/scenes/boss-types/BoneKnightBoss.ts
@@ -47,6 +47,8 @@ export class BoneKnightBoss extends Phaser.Scene {
         this.playerHp = 5
         this.phase = 1
         this.activeShieldIndex = 0
+        this.horses = []
+        this.wordQueue = []
     }
 
     create() {

--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -46,6 +46,9 @@ export class GrizzlefangBoss extends Phaser.Scene {
     this.finished = false
     this.playerHp = 5
     this.phase = 1
+    this.wordQueue = []
+    this.wrongKeyCount = 0
+    this.nextAttackThreshold = 0
     // Number of words is dictated by config, let's distribute evenly across 3 phases
     this.wordsPerPhase = Math.max(1, Math.ceil(this.level.wordCount / this.maxPhases))
     // Check if player has studied the Monster Manual for this boss

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -39,6 +39,10 @@ export class MiniBossTypical extends Phaser.Scene {
     this.profileSlot = data.profileSlot
     this.finished = false
     this.playerHp = 3
+    this.words = []
+    this.wordQueue = []
+    this.wrongKeyCount = 0
+    this.nextAttackThreshold = 0
     const profile = loadProfile(data.profileSlot)
     this.weaknessActive = profile?.bossWeaknessKnown === (data.level.bossId ?? '')
     this.gameMode = profile?.gameMode ?? 'regular'

--- a/src/scenes/boss-types/TypemancerBoss.ts
+++ b/src/scenes/boss-types/TypemancerBoss.ts
@@ -43,6 +43,7 @@ export class TypemancerBoss extends Phaser.Scene {
     this.finished = false
     this.playerHp = 5
     this.phase = 1
+    this.wordQueue = []
     // Number of words is dictated by config, distributed across 5 phases
     this.wordsPerPhase = Math.max(1, Math.ceil(this.level.wordCount / this.maxPhases))
   }

--- a/src/scenes/level-types/GoblinWhackerLevel.ts
+++ b/src/scenes/level-types/GoblinWhackerLevel.ts
@@ -54,6 +54,13 @@ export class GoblinWhackerLevel extends Phaser.Scene {
     this.finished = false
     this.goblinsDefeated = 0
     this.playerHp = 3
+    this.goblins = []
+    this.activeGoblin = null
+    this.words = []
+    this.wordQueue = []
+    this.timeLeft = 0
+    this.letterShieldCount = 0
+    this.hpHearts = []
     const profile = loadProfile(data.profileSlot)
     this.gameMode = profile?.gameMode ?? 'regular'
   }

--- a/src/scenes/level-types/MonsterArenaLevel.ts
+++ b/src/scenes/level-types/MonsterArenaLevel.ts
@@ -37,6 +37,10 @@ export class MonsterArenaLevel extends Phaser.Scene {
     this.profileSlot = data.profileSlot
     this.finished = false
     this.playerHp = 3
+    this.monsters = []
+    this.activeMonster = null
+    this.words = []
+    this.wordQueue = []
   }
 
   create() {

--- a/src/scenes/level-types/SkeletonSwarmLevel.ts
+++ b/src/scenes/level-types/SkeletonSwarmLevel.ts
@@ -43,6 +43,10 @@ export class SkeletonSwarmLevel extends Phaser.Scene {
     this.playerHp = 3
     this.currentWave = 0
     this.maxWaves = Phaser.Math.Between(3, 5) // 3-5 waves
+    this.skeletons = []
+    this.activeSkeleton = null
+    this.words = []
+    this.wordQueue = []
   }
 
   create() {

--- a/src/scenes/level-types/SlimeSplittingLevel.ts
+++ b/src/scenes/level-types/SlimeSplittingLevel.ts
@@ -37,6 +37,10 @@ export class SlimeSplittingLevel extends Phaser.Scene {
     this.profileSlot = data.profileSlot
     this.finished = false
     this.playerHp = 3
+    this.slimes = []
+    this.activeSlime = null
+    this.words = []
+    this.wordQueue = []
   }
 
   create() {

--- a/src/scenes/level-types/UndeadSiegeLevel.ts
+++ b/src/scenes/level-types/UndeadSiegeLevel.ts
@@ -42,6 +42,10 @@ export class UndeadSiegeLevel extends Phaser.Scene {
     this.undeadsDefeated = 0
     this.castleHp = 5
     this.currentWave = 1
+    this.undeads = []
+    this.activeUndead = null
+    this.words = []
+    this.wordQueue = []
   }
 
   create() {

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -43,8 +43,30 @@ export function pickWords(pool: string[], count: number, difficulty: number): st
 }
 
 export function getWordPool(unlockedLetters: string[], count: number, difficulty: number, maxLength?: number): string[] {
-  const filtered = filterWordsByLetters(WORD_BANK, unlockedLetters, maxLength)
-  return pickWords(filtered, Math.min(count, filtered.length), difficulty)
+  let filtered = filterWordsByLetters(WORD_BANK, unlockedLetters, maxLength)
+
+  // Fallback: If no words match the criteria, use the base home row letters
+  if (filtered.length === 0) {
+    const fallbackLetters = ['a', 's', 'd', 'f', 'j', 'k', 'l']
+    filtered = filterWordsByLetters(WORD_BANK, fallbackLetters, maxLength)
+
+    // If it's still somehow empty (e.g. extremely strict maxLength), just grab any words
+    if (filtered.length === 0) {
+      filtered = [...WORD_BANK]
+    }
+  }
+
+  // If the filtered pool doesn't have enough words to fulfill the count without repeats,
+  // we could potentially repeat words. However, the existing logic caps it at filtered.length.
+  // We'll leave the pickWords call as is but ensure we return at least one word.
+  const selected = pickWords(filtered, Math.min(count, filtered.length), difficulty)
+
+  // Absolute fallback to ensure we never return an empty array if count > 0
+  if (selected.length === 0 && count > 0) {
+    selected.push(WORD_BANK[0])
+  }
+
+  return selected
 }
 
 export function calculateWpm(wordCount: number, elapsedMs: number): number {


### PR DESCRIPTION
This PR fixes an issue where starting a level (like a Goblin Whacker level) would sometimes spawn no enemies, or when enemies did appear, the player's typing would not register. 

These issues were caused by:
1. **Stale Scene State:** Phaser reuses Scene instances when a scene is restarted or re-entered. For levels and bosses, entity arrays (like `this.goblins`) and active references (`this.activeGoblin`) were initialized only once when the class was created, rather than cleared in the `init()` method. Thus, if a player restarted a level, the scene thought there were already max entities on screen or the `activeGoblin` reference pointed to a stale object.
2. **Empty Word Pools:** If a level requested a pool of words based on unlocked letters and max lengths, but the filter left no valid words, `getWordPool()` returned an empty array. `spawnGoblin()` (and other entity spawners) would then pull `undefined` from the empty queue or exit early, causing no entities to appear.

**Changes:**
- Added cleanup logic to the `init()` method of all `level-types` and `boss-types` scenes to reset their core state arrays and references.
- Added layered fallback logic in `src/utils/words.ts` `getWordPool()` to fall back to home-row letters and then the full word bank if the strict filter yields an empty array, guaranteeing words are always available.

---
*PR created automatically by Jules for task [3839215572327815815](https://jules.google.com/task/3839215572327815815) started by @flamableconcrete*