### PR TITLE
Fix PauseScene visibility in MiniBossTypical

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ const game = new Phaser.Game({
     GoblinWhackerLevel, SkeletonSwarmLevel, MonsterArenaLevel, UndeadSiegeLevel, SlimeSplittingLevel,
     DungeonTrapDisarmLevel, DungeonEscapeLevel, PotionBrewingLabLevel, MagicRuneTypingLevel,
     MonsterManualLevel, WoodlandFestivalLevel, SillyChallengeLevel, GuildRecruitmentLevel,
-    BossBattleScene, InventoryScene, TavernScene, StableScene, CutsceneScene, VictoryScene, SettingsScene, PauseScene, MiniBossTypical, GrizzlefangBoss, HydraBoss, SlimeKingBoss, ClockworkDragonBoss, BaronTypoBoss, SpiderBoss, FlashWordBoss, BoneKnightBoss, DiceLichBoss, AncientDragonBoss, TypemancerBoss
+    BossBattleScene, InventoryScene, TavernScene, StableScene, CutsceneScene, VictoryScene, SettingsScene, MiniBossTypical, GrizzlefangBoss, HydraBoss, SlimeKingBoss, ClockworkDragonBoss, BaronTypoBoss, SpiderBoss, FlashWordBoss, BoneKnightBoss, DiceLichBoss, AncientDragonBoss, TypemancerBoss, PauseScene
   ],
 });
 

--- a/src/utils/pauseSetup.ts
+++ b/src/utils/pauseSetup.ts
@@ -15,6 +15,7 @@ export function setupPause(scene: Phaser.Scene, profileSlot: number) {
   pauseBtn.on('pointerdown', () => {
     scene.scene.pause()
     scene.scene.launch('PauseScene', { levelKey: scene.scene.key, profileSlot })
+    scene.scene.bringToTop('PauseScene')
   })
 
   pauseBtn.on('pointerover', () => pauseBtn.setColor('#ffffff'))
@@ -24,5 +25,6 @@ export function setupPause(scene: Phaser.Scene, profileSlot: number) {
   scene.input.keyboard?.on('keydown-ESC', () => {
     scene.scene.pause()
     scene.scene.launch('PauseScene', { levelKey: scene.scene.key, profileSlot })
+    scene.scene.bringToTop('PauseScene')
   })
 }


### PR DESCRIPTION
Fixes an issue where pressing Escape in `MiniBossTypical` (or clicking the UI button) successfully triggered the `PauseScene` logic, but the actual pause overlay was hidden behind the mini-boss scene's opaque background rectangle. The issue was solved by fixing the `PauseScene` rendering depth order.

---
*PR created automatically by Jules for task [9038160128818641396](https://jules.google.com/task/9038160128818641396) started by @flamableconcrete*