### PR TITLE
Add full-body rendering for player avatars

### DIFF
--- a/src/components/AvatarRenderer.ts
+++ b/src/components/AvatarRenderer.ts
@@ -3,7 +3,8 @@ import { AVATAR_CONFIGS, type AvatarConfig } from '../data/avatars'
 
 const GRID = 16
 const PIXEL = 3
-const SIZE = GRID * PIXEL // 48
+const WIDTH = GRID * PIXEL // 48
+const HEIGHT = 32 * PIXEL // 96
 
 export class AvatarRenderer {
   static generateAll(scene: Phaser.Scene): void {
@@ -14,13 +15,14 @@ export class AvatarRenderer {
   }
 
   static generateOne(scene: Phaser.Scene, config: AvatarConfig): void {
-    const rt = scene.make.renderTexture({ width: SIZE, height: SIZE }, false)
+    const rt = scene.make.renderTexture({ width: WIDTH, height: HEIGHT }, false)
     const gfx = scene.make.graphics({}, false)
 
-    AvatarRenderer.drawHead(gfx, config.skinTone)
+AvatarRenderer.drawHead(gfx, config.skinTone)
     AvatarRenderer.drawEyes(gfx, config.eyeColor, config.hairColor)
     AvatarRenderer.drawMouth(gfx)
     AvatarRenderer.drawHair(gfx, config.hairStyle, config.hairColor)
+    AvatarRenderer.drawBody(gfx, config)
     AvatarRenderer.drawAccessory(gfx, config.accessory, config.hairColor)
 
     rt.draw(gfx)
@@ -158,6 +160,39 @@ export class AvatarRenderer {
         AvatarRenderer.rect(gfx, 15, 6, 1, 3, color)
         break
     }
+  }
+
+  // ── Body ──────────────────────────────────────────────────
+
+  private static drawBody(gfx: Phaser.GameObjects.Graphics, config: AvatarConfig): void {
+    const { skinTone, shirtColor, pantsColor, shoeColor } = config
+
+    // Torso (shirt): cols 4-11, rows 16-23
+    AvatarRenderer.rect(gfx, 4, 16, 8, 8, shirtColor)
+
+    // Shoulders/Arms (shirt): cols 2-3 and 12-13, rows 16-20
+    AvatarRenderer.rect(gfx, 2, 16, 2, 5, shirtColor)
+    AvatarRenderer.rect(gfx, 12, 16, 2, 5, shirtColor)
+
+    // Hands (skin): cols 2-3 and 12-13, rows 21-23
+    AvatarRenderer.rect(gfx, 2, 21, 2, 3, skinTone)
+    AvatarRenderer.rect(gfx, 12, 21, 2, 3, skinTone)
+
+    // Pants (Left Leg): cols 4-7, rows 24-28
+    AvatarRenderer.rect(gfx, 4, 24, 3, 5, pantsColor)
+
+    // Pants (Right Leg): cols 9-12, rows 24-28
+    AvatarRenderer.rect(gfx, 9, 24, 3, 5, pantsColor)
+
+    // Waistband
+    AvatarRenderer.rect(gfx, 4, 24, 8, 1, pantsColor)
+
+    // Shoes: cols 3-6 and 9-12, rows 29-30
+    AvatarRenderer.rect(gfx, 4, 29, 3, 2, shoeColor)
+    AvatarRenderer.rect(gfx, 9, 29, 3, 2, shoeColor)
+    // Shoe tips
+    AvatarRenderer.rect(gfx, 3, 30, 1, 1, shoeColor)
+    AvatarRenderer.rect(gfx, 12, 30, 1, 1, shoeColor)
   }
 
   // ── Accessories ───────────────────────────────────────────

--- a/src/data/avatars.ts
+++ b/src/data/avatars.ts
@@ -18,6 +18,9 @@ export interface AvatarConfig {
   hairColor: number;
   eyeColor: number;
   accessory: Accessory;
+  shirtColor: number;
+  pantsColor: number;
+  shoeColor: number;
 }
 
 const SKIN_TONES: number[] = [
@@ -81,6 +84,41 @@ const ACCESSORIES: Accessory[] = [
   'bandana',
 ];
 
+
+const SHIRT_COLORS: number[] = [
+  0xff3b30, // red
+  0xff9500, // orange
+  0xffcc00, // yellow
+  0x4cd964, // green
+  0x5ac8fa, // light blue
+  0x007aff, // blue
+  0x5856d6, // purple
+  0xff2d55, // pink
+  0xffffff, // white
+  0x8e8e93, // gray
+  0x1c1c1e, // black
+];
+
+const PANTS_COLORS: number[] = [
+  0x0a4a8f, // dark blue jeans
+  0x2a7bcf, // light blue jeans
+  0x222222, // black slacks
+  0x444444, // dark gray slacks
+  0x8b7355, // brown khakis
+  0xc1a073, // light khakis
+  0x3c3c3c, // dark shorts
+  0x556b2f, // olive cargo
+];
+
+const SHOE_COLORS: number[] = [
+  0x2c1b0e, // dark brown
+  0x5a3d2b, // brown
+  0x111111, // black
+  0xeeeeee, // white
+  0x888888, // gray
+  0x8b0000, // dark red
+];
+
 function generateAvatarConfigs(): AvatarConfig[] {
   const configs: AvatarConfig[] = [];
 
@@ -89,14 +127,20 @@ function generateAvatarConfigs(): AvatarConfig[] {
   const hairStyleOffset = 3;
   const hairColorOffset = 7;
   const eyeColorOffset = 11;
-  const accessoryOffset = 5;
+const accessoryOffset = 5;
+  const shirtColorOffset = 13;
+  const pantsColorOffset = 17;
+  const shoeColorOffset = 19;
 
   for (let i = 0; i < 30; i++) {
     const skinIndex = (i * 3 + skinOffset) % SKIN_TONES.length;
     const hairStyleIndex = (i * 2 + hairStyleOffset) % HAIR_STYLES.length;
     const hairColorIndex = (i * 5 + hairColorOffset) % HAIR_COLORS.length;
     const eyeColorIndex = (i * 3 + eyeColorOffset) % EYE_COLORS.length;
-    const accessoryIndex = (i * 7 + accessoryOffset) % ACCESSORIES.length;
+const accessoryIndex = (i * 7 + accessoryOffset) % ACCESSORIES.length;
+    const shirtColorIndex = (i * 13 + shirtColorOffset) % SHIRT_COLORS.length;
+    const pantsColorIndex = (i * 17 + pantsColorOffset) % PANTS_COLORS.length;
+    const shoeColorIndex = (i * 19 + shoeColorOffset) % SHOE_COLORS.length;
 
     configs.push({
       id: `avatar_${i}`,
@@ -105,6 +149,9 @@ function generateAvatarConfigs(): AvatarConfig[] {
       hairColor: HAIR_COLORS[hairColorIndex],
       eyeColor: EYE_COLORS[eyeColorIndex],
       accessory: ACCESSORIES[accessoryIndex],
+      shirtColor: SHIRT_COLORS[shirtColorIndex],
+      pantsColor: PANTS_COLORS[pantsColorIndex],
+      shoeColor: SHOE_COLORS[shoeColorIndex],
     });
   }
 
@@ -117,13 +164,16 @@ export function randomizeAvatarConfigs(): void {
   AVATAR_CONFIGS.length = 0;
   const ts = Date.now();
   for (let i = 0; i < 30; i++) {
-    AVATAR_CONFIGS.push({
+AVATAR_CONFIGS.push({
       id: `avatar_${ts}_${i}`,
       skinTone: SKIN_TONES[Math.floor(Math.random() * SKIN_TONES.length)],
       hairStyle: HAIR_STYLES[Math.floor(Math.random() * HAIR_STYLES.length)],
       hairColor: HAIR_COLORS[Math.floor(Math.random() * HAIR_COLORS.length)],
       eyeColor: EYE_COLORS[Math.floor(Math.random() * EYE_COLORS.length)],
       accessory: ACCESSORIES[Math.floor(Math.random() * ACCESSORIES.length)],
+      shirtColor: SHIRT_COLORS[Math.floor(Math.random() * SHIRT_COLORS.length)],
+      pantsColor: PANTS_COLORS[Math.floor(Math.random() * PANTS_COLORS.length)],
+      shoeColor: SHOE_COLORS[Math.floor(Math.random() * SHOE_COLORS.length)],
     });
   }
 }

--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -122,9 +122,10 @@ export class OverlandMapScene extends Phaser.Scene {
 
     const avatarTexture = this.profile.avatarChoice || 'avatar_0'
     this.avatarBasePos = { x: startPos.x, y: startPos.y }
-    this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(1000)
+this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(1000)
     // Scale down the pixel art avatar slightly to fit the map nodes better
     this.avatar.setScale(0.75)
+    this.avatar.setOrigin(0.5, 1) // Anchor at bottom center so feet touch the node
   }
 
   update(time: number) {

--- a/src/scenes/ProfileSelectScene.ts
+++ b/src/scenes/ProfileSelectScene.ts
@@ -92,7 +92,7 @@ export class ProfileSelectScene extends Phaser.Scene {
     // Avatar
     const avatarX = width / 2 - panelW / 2 + 50
     const avatarKey = this.textures.exists(profile.avatarChoice) ? profile.avatarChoice : 'avatar_0'
-    this.add.image(avatarX, y, avatarKey).setDisplaySize(48, 48)
+    this.add.image(avatarX, y, avatarKey).setDisplaySize(36, 72)
 
     // Player name
     const textStartX = avatarX + 45
@@ -264,7 +264,7 @@ export class ProfileSelectScene extends Phaser.Scene {
       frame.setStrokeStyle(2, 0x4444aa)
 
       // Avatar image
-      const img = this.add.image(ax, ay, config.id).setDisplaySize(48, 48)
+      const img = this.add.image(ax, ay, config.id).setDisplaySize(36, 72)
       img.setInteractive({ useHandCursor: true })
 
       // Default selection highlight for first avatar

--- a/src/scenes/SettingsScene.ts
+++ b/src/scenes/SettingsScene.ts
@@ -35,7 +35,7 @@ export class SettingsScene extends Phaser.Scene {
 
     // Avatar Section
     const avatarKey = this.textures.exists(profile.avatarChoice) ? profile.avatarChoice : 'avatar_0'
-    this.add.image(width / 2, 130, avatarKey).setDisplaySize(64, 64)
+    this.add.image(width / 2, 130, avatarKey).setDisplaySize(48, 96)
 
     const changeAvatarBtn = this.add.text(width / 2, 180, '[ Change Avatar ]', {
       fontSize: '20px',
@@ -169,7 +169,7 @@ export class SettingsScene extends Phaser.Scene {
       frame.setStrokeStyle(2, 0x4444aa)
 
       // Avatar image
-      const img = this.add.image(ax, ay, config.id).setDisplaySize(48, 48)
+      const img = this.add.image(ax, ay, config.id).setDisplaySize(36, 72)
       img.setInteractive({ useHandCursor: true })
 
       // Default selection highlight


### PR DESCRIPTION
This commit updates the player avatar generation so that it renders a full body (torso, arms, legs, shoes) instead of just a head. New color configurations (shirts, pants, shoes) have been added to the avatar definitions, and the various scenes have been adjusted to render the new 1:2 aspect ratio avatar sprites correctly.

---
*PR created automatically by Jules for task [7833050190255001983](https://jules.google.com/task/7833050190255001983) started by @flamableconcrete*