### PR TITLE
fix: remove unused destructured variables from pauseSetup.ts

### DIFF
--- a/src/utils/pauseSetup.ts
+++ b/src/utils/pauseSetup.ts
@@ -1,8 +1,6 @@
 import Phaser from 'phaser'
 
 export function setupPause(scene: Phaser.Scene, profileSlot: number) {
-  const { width, height } = scene.scale
-
   // Add a subtle "Pause / Quit" button in the top left corner
   // so it doesn't conflict with timers, HP, or typing area
   const pauseBtn = scene.add.text(20, 20, '[ ESC to Pause ]', {


### PR DESCRIPTION
Remove unused `width` and `height` destructuring from `scene.scale`
that caused a TS6198 TypeScript error breaking the build.

https://claude.ai/code/session_01NXBd94YmYADKU2Pk37iudP