### PR TITLE
feat: add PROFILES button to overworld map

### DIFF
--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -105,6 +105,7 @@ export class OverlandMapScene extends Phaser.Scene {
     this.drawSpecialNodes(mapData.specialNodes)
     this.drawMasteryChest()
     this.drawSettingsButton()
+    this.drawProfilesButton()
 
     let startPos = mapData.nodePositions[0] || { x: 0, y: 0 }
     this.currentNodeIndex = 0
@@ -463,13 +464,25 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
 
   private drawSettingsButton() {
     const { width } = this.scale
-    const btn = this.add.text(width - 20, 50, '⚙ SETTINGS', {
-      fontSize: '18px', color: '#aaaaaa'
+    const btn = this.add.text(width - 20, 20, '⚙ SETTINGS', {
+      fontSize: '18px', color: '#aaaaaa', backgroundColor: '#222222', padding: { x: 8, y: 4 }
     }).setOrigin(1, 0).setInteractive({ useHandCursor: true }).setDepth(2000)
     btn.on('pointerover', () => btn.setColor('#ffffff'))
     btn.on('pointerout', () => btn.setColor('#aaaaaa'))
     btn.on('pointerdown', () => {
       this.scene.start('Settings', { profileSlot: this.profileSlot })
+    })
+  }
+
+  private drawProfilesButton() {
+    const { width } = this.scale
+    const btn = this.add.text(width - 20, 55, '👥 PROFILES', {
+      fontSize: '18px', color: '#aaaaaa', backgroundColor: '#222222', padding: { x: 8, y: 4 }
+    }).setOrigin(1, 0).setInteractive({ useHandCursor: true }).setDepth(2000)
+    btn.on('pointerover', () => btn.setColor('#ffffff'))
+    btn.on('pointerout', () => btn.setColor('#aaaaaa'))
+    btn.on('pointerdown', () => {
+      this.scene.start('ProfileSelect')
     })
   }
 


### PR DESCRIPTION
Adds a "PROFILES" button to the `OverlandMapScene` next to the "SETTINGS" button. Clicking this button lets the user return to the "Select Your Hero" profile select screen, effectively allowing them to exit the current profile's game session and swap to another profile. Includes minor visual improvements to the settings button as well to match the new profile button.

---
*PR created automatically by Jules for task [7408223248501415639](https://jules.google.com/task/7408223248501415639) started by @flamableconcrete*