### PR TITLE
Add visual avatars for companions and pets

### DIFF
--- a/src/art/companionsArt.ts
+++ b/src/art/companionsArt.ts
@@ -1,0 +1,128 @@
+import Phaser from 'phaser'
+
+
+export function generateAllCompanionTextures(scene: Phaser.Scene) {
+  generateCompanionTexture(scene, 'mouse_guard_scout')
+  generateCompanionTexture(scene, 'badger_warrior')
+  generateCompanionTexture(scene, 'wizard_apprentice')
+  generateCompanionTexture(scene, 'archer')
+
+  generatePetTexture(scene, 'goblin')
+  generatePetTexture(scene, 'slime')
+  generatePetTexture(scene, 'skeleton')
+  generatePetTexture(scene, 'baby_dragon')
+}
+
+export function generateCompanionTexture(scene: Phaser.Scene, companionId: string) {
+  if (scene.textures.exists(companionId)) return
+
+  const g = scene.add.graphics()
+  const s = 3 // pixel scale
+
+  switch (companionId) {
+    case 'mouse_guard_scout':
+      // Mouse body
+      g.fillStyle(0x888888)
+      g.fillRect(3*s, 4*s, 6*s, 8*s)
+      // Ears
+      g.fillCircle(3*s, 3*s, 2*s)
+      g.fillCircle(9*s, 3*s, 2*s)
+      g.fillStyle(0xffcccc)
+      g.fillCircle(3*s, 3*s, 1*s)
+      g.fillCircle(9*s, 3*s, 1*s)
+      // Eyes
+      g.fillStyle(0x000000)
+      g.fillRect(4*s, 5*s, 1*s, 1*s)
+      g.fillRect(7*s, 5*s, 1*s, 1*s)
+      // Cape
+      g.fillStyle(0x228b22)
+      g.fillRect(2*s, 6*s, 8*s, 5*s)
+      break
+    case 'badger_warrior':
+      // Badger body
+      g.fillStyle(0x333333)
+      g.fillRect(3*s, 3*s, 8*s, 10*s)
+      // White stripe
+      g.fillStyle(0xffffff)
+      g.fillRect(6*s, 2*s, 2*s, 11*s)
+      // Axe
+      g.fillStyle(0x8b4513)
+      g.fillRect(1*s, 5*s, 2*s, 8*s)
+      g.fillStyle(0xaaaaaa)
+      g.fillRect(0*s, 4*s, 4*s, 3*s)
+      break
+    case 'wizard_apprentice':
+      // Robe
+      g.fillStyle(0x4b0082)
+      g.fillRect(4*s, 6*s, 6*s, 8*s)
+      // Hat
+      g.fillTriangle(4*s, 6*s, 7*s, 0*s, 10*s, 6*s)
+      g.fillRect(3*s, 6*s, 8*s, 1*s)
+      // Staff
+      g.fillStyle(0x8b4513)
+      g.fillRect(11*s, 2*s, 1*s, 12*s)
+      g.fillStyle(0xffff00)
+      g.fillCircle(11*s + s/2, 2*s, 2*s)
+      break
+    case 'archer':
+      // Tunic
+      g.fillStyle(0x006400)
+      g.fillRect(4*s, 5*s, 6*s, 7*s)
+      // Bow
+      g.fillStyle(0x8b4513)
+      g.strokeCircle(8*s, 8*s, 4*s)
+      g.fillStyle(0x000000)
+      g.fillRect(8*s, 4*s, 1*s, 8*s) // string
+      break
+  }
+
+  g.generateTexture(companionId, 16 * s, 16 * s)
+  g.destroy()
+}
+
+export function generatePetTexture(scene: Phaser.Scene, petId: string) {
+  if (scene.textures.exists(petId)) return
+
+  const g = scene.add.graphics()
+  const s = 3
+
+  switch (petId) {
+    case 'goblin':
+      g.fillStyle(0x44aa44)
+      g.fillRect(4*s, 6*s, 8*s, 6*s) // body
+      g.fillStyle(0x55cc55)
+      g.fillRect(5*s, 3*s, 6*s, 4*s) // head
+      g.fillStyle(0xff2222)
+      g.fillRect(6*s, 4*s, 1*s, 1*s) // eye
+      g.fillRect(9*s, 4*s, 1*s, 1*s) // eye
+      break
+    case 'slime':
+      g.fillStyle(0x00ff00, 0.8)
+      g.fillCircle(8*s, 10*s, 5*s)
+      g.fillRect(3*s, 10*s, 10*s, 4*s)
+      g.fillStyle(0x000000)
+      g.fillRect(6*s, 9*s, 1*s, 1*s)
+      g.fillRect(9*s, 9*s, 1*s, 1*s)
+      break
+    case 'skeleton':
+      g.fillStyle(0xeeeeee)
+      g.fillRect(5*s, 2*s, 6*s, 5*s) // skull
+      g.fillRect(7*s, 7*s, 2*s, 5*s) // spine
+      g.fillRect(4*s, 8*s, 8*s, 1*s) // ribs
+      g.fillStyle(0x000000)
+      g.fillRect(6*s, 4*s, 1*s, 1*s) // eye
+      g.fillRect(9*s, 4*s, 1*s, 1*s) // eye
+      break
+    case 'baby_dragon':
+      g.fillStyle(0xff4444)
+      g.fillRect(4*s, 6*s, 8*s, 6*s) // body
+      g.fillCircle(12*s, 5*s, 3*s) // head
+      g.fillStyle(0xffaa00)
+      g.fillTriangle(2*s, 8*s, 4*s, 6*s, 4*s, 10*s) // tail
+      g.fillTriangle(6*s, 6*s, 8*s, 3*s, 10*s, 6*s) // wing
+      break
+  }
+
+  g.generateTexture(petId, 16 * s, 16 * s)
+  g.destroy()
+}

--- a/src/scenes/StableScene.ts
+++ b/src/scenes/StableScene.ts
@@ -3,6 +3,7 @@ import { loadProfile, saveProfile } from '../utils/profile'
 import { calcCompanionLevel } from '../utils/scoring'
 import { PET_TEMPLATES, createCompanion } from '../data/companions'
 import { ProfileData, CompanionData } from '../types'
+import { generateAllCompanionTextures } from '../art/companionsArt'
 
 export class StableScene extends Phaser.Scene {
   private profileSlot!: number
@@ -17,6 +18,8 @@ export class StableScene extends Phaser.Scene {
 
   create() {
     const { width, height } = this.scale
+
+    generateAllCompanionTextures(this)
 
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a2a1a)
 
@@ -89,8 +92,9 @@ export class StableScene extends Phaser.Scene {
     const level = calcCompanionLevel(pet.xp)
     const bg = this.add.rectangle(x, y, 260, 150, isActive ? 0x224422 : 0x223322)
       .setInteractive({ useHandCursor: true })
-    this.add.text(x, y - 50, pet.name, { fontSize: '14px', color: '#ffffff', wordWrap: { width: 240 } }).setOrigin(0.5)
-    this.add.text(x, y - 10, `Level ${level} · x${pet.autoStrikeCount} auto-strike`, { fontSize: '14px', color: '#aaffaa' }).setOrigin(0.5)
+    this.add.image(x - 90, y - 40, pet.id).setScale(2)
+    this.add.text(x, y - 50, pet.name, { fontSize: '14px', color: '#ffffff', wordWrap: { width: 180 } }).setOrigin(0.5)
+    this.add.text(x, y - 15, `Level ${level} · x${pet.autoStrikeCount} auto-strike`, { fontSize: '14px', color: '#aaffaa' }).setOrigin(0.5)
     this.add.text(x, y + 20, pet.backstory, { fontSize: '11px', color: '#888888', wordWrap: { width: 240 } }).setOrigin(0.5)
     const activeLabel = isActive ? '✓ Active' : '[ Set Active ]'
     this.add.text(x, y + 55, activeLabel, {

--- a/src/scenes/TavernScene.ts
+++ b/src/scenes/TavernScene.ts
@@ -3,6 +3,7 @@ import { loadProfile, saveProfile } from '../utils/profile'
 import { COMPANION_TEMPLATES, createCompanion } from '../data/companions'
 import { calcCompanionLevel } from '../utils/scoring'
 import { ProfileData, CompanionData } from '../types'
+import { generateAllCompanionTextures } from '../art/companionsArt'
 
 export class TavernScene extends Phaser.Scene {
   private profileSlot!: number
@@ -17,6 +18,8 @@ export class TavernScene extends Phaser.Scene {
 
   create() {
     const { width, height } = this.scale
+
+    generateAllCompanionTextures(this)
 
     this.add.rectangle(width / 2, height / 2, width, height, 0x2a1a0a)
 
@@ -89,8 +92,9 @@ export class TavernScene extends Phaser.Scene {
     const level = calcCompanionLevel(companion.xp)
     const bg = this.add.rectangle(x, y, 260, 150, isActive ? 0x334433 : 0x222244)
       .setInteractive({ useHandCursor: true })
-    this.add.text(x, y - 50, companion.name, { fontSize: '14px', color: '#ffffff', wordWrap: { width: 240 } }).setOrigin(0.5)
-    this.add.text(x, y - 10, `Level ${level} · x${companion.autoStrikeCount} auto-strike`, { fontSize: '14px', color: '#aaffaa' }).setOrigin(0.5)
+    this.add.image(x - 90, y - 40, companion.id).setScale(2)
+    this.add.text(x, y - 50, companion.name, { fontSize: '14px', color: '#ffffff', wordWrap: { width: 180 } }).setOrigin(0.5)
+    this.add.text(x, y - 15, `Level ${level} · x${companion.autoStrikeCount} auto-strike`, { fontSize: '14px', color: '#aaffaa' }).setOrigin(0.5)
     this.add.text(x, y + 20, companion.backstory, { fontSize: '11px', color: '#888888', wordWrap: { width: 240 } }).setOrigin(0.5)
     const activeLabel = isActive ? '✓ Active' : '[ Set Active ]'
     this.add.text(x, y + 55, activeLabel, { fontSize: '14px', color: isActive ? '#44ff44' : '#aaaaff' }).setOrigin(0.5)

--- a/src/scenes/boss-types/AncientDragonBoss.ts
+++ b/src/scenes/boss-types/AncientDragonBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class AncientDragonBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -51,8 +52,15 @@ export class AncientDragonBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x0a001a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/BaronTypoBoss.ts
+++ b/src/scenes/boss-types/BaronTypoBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class BaronTypoBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -54,8 +55,15 @@ export class BaronTypoBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a0a2a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/BoneKnightBoss.ts
+++ b/src/scenes/boss-types/BoneKnightBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Shield {
     sprite: Phaser.GameObjects.Arc | Phaser.GameObjects.Rectangle
@@ -62,8 +63,15 @@ export class BoneKnightBoss extends Phaser.Scene {
         this.add.rectangle(width / 2, height / 2, width, height, 0x0a0a0a)
 
         const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
         this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/ClockworkDragonBoss.ts
+++ b/src/scenes/boss-types/ClockworkDragonBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Gear {
   container: Phaser.GameObjects.Container
@@ -68,8 +69,15 @@ export class ClockworkDragonBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a1a1a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/DiceLichBoss.ts
+++ b/src/scenes/boss-types/DiceLichBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class DiceLichBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -55,8 +56,15 @@ export class DiceLichBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x050505)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, { 

--- a/src/scenes/boss-types/FlashWordBoss.ts
+++ b/src/scenes/boss-types/FlashWordBoss.ts
@@ -6,6 +6,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class FlashWordBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -46,8 +47,15 @@ export class FlashWordBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a0a2e)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
 
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -8,6 +8,7 @@ import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { generateGoblinWhackerTextures } from '../../art/goblinWhackerArt'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class GrizzlefangBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -70,8 +71,15 @@ export class GrizzlefangBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x111111)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/HydraBoss.ts
+++ b/src/scenes/boss-types/HydraBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Head {
   sprite: Phaser.GameObjects.Rectangle
@@ -64,8 +65,15 @@ export class HydraBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x051a05)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/MiniBossTypical.ts
+++ b/src/scenes/boss-types/MiniBossTypical.ts
@@ -10,6 +10,7 @@ import { TypingHands } from '../../components/TypingHands'
 import { generateGoblinWhackerTextures } from '../../art/goblinWhackerArt'
 import { generateGenericBossTextures } from '../../art/genericBossArt'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class MiniBossTypical extends Phaser.Scene {
   private level!: LevelConfig
@@ -62,10 +63,17 @@ export class MiniBossTypical extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x4a1e2a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
 
     // Prominent Avatar on the left
     this.add.image(width * 0.25, height / 2 - 50, avatarKey).setScale(2.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(width * 0.25 + 100, height / 2, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/SlimeKingBoss.ts
+++ b/src/scenes/boss-types/SlimeKingBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Slime {
   word: string
@@ -52,8 +53,15 @@ export class SlimeKingBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x111111)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/SpiderBoss.ts
+++ b/src/scenes/boss-types/SpiderBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface WebLine {
   index: number;
@@ -72,8 +73,15 @@ export class SpiderBoss extends Phaser.Scene {
     this.add.rectangle(centerX, centerY, width, height, 0x0a0a1a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/boss-types/TypemancerBoss.ts
+++ b/src/scenes/boss-types/TypemancerBoss.ts
@@ -7,6 +7,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class TypemancerBoss extends Phaser.Scene {
   private level!: LevelConfig
@@ -57,8 +58,15 @@ export class TypemancerBoss extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x000000)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+  const pProfile = loadProfile(this.profileSlot)
+  const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+  if (activeCompanion) {
+      this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+  }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/level-types/CharacterCreatorLevel.ts
+++ b/src/scenes/level-types/CharacterCreatorLevel.ts
@@ -1,3 +1,4 @@
+
 // src/scenes/level-types/CharacterCreatorLevel.ts
 import Phaser from 'phaser'
 import { LevelConfig } from '../../types'

--- a/src/scenes/level-types/DungeonEscapeLevel.ts
+++ b/src/scenes/level-types/DungeonEscapeLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class DungeonEscapeLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -38,8 +39,15 @@ export class DungeonEscapeLevel extends Phaser.Scene {
 
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     // Level name

--- a/src/scenes/level-types/DungeonTrapDisarmLevel.ts
+++ b/src/scenes/level-types/DungeonTrapDisarmLevel.ts
@@ -7,6 +7,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Trap {
   word: string
@@ -55,8 +56,15 @@ export class DungeonTrapDisarmLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x3a2e3a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/level-types/GoblinWhackerLevel.ts
+++ b/src/scenes/level-types/GoblinWhackerLevel.ts
@@ -10,6 +10,7 @@ import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { generateGoblinWhackerTextures } from '../../art/goblinWhackerArt'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Goblin {
   word: string
@@ -86,8 +87,15 @@ export class GoblinWhackerLevel extends Phaser.Scene {
 
     // Hero sprite
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(80, this.pathY, avatarKey).setScale(1.5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(160, this.pathY + 10, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD - HP hearts
     this.hpHearts = []

--- a/src/scenes/level-types/GuildRecruitmentLevel.ts
+++ b/src/scenes/level-types/GuildRecruitmentLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class GuildRecruitmentLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -34,8 +35,15 @@ export class GuildRecruitmentLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x4a2e1b)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.add.text(width / 2, 40, this.level.name, {

--- a/src/scenes/level-types/MagicRuneTypingLevel.ts
+++ b/src/scenes/level-types/MagicRuneTypingLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class MagicRuneTypingLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -43,8 +44,15 @@ export class MagicRuneTypingLevel extends Phaser.Scene {
 
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     // Level name

--- a/src/scenes/level-types/MonsterArenaLevel.ts
+++ b/src/scenes/level-types/MonsterArenaLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Monster {
   word: string
@@ -52,8 +53,15 @@ export class MonsterArenaLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x4a1e1e)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, { fontSize: '22px', color: '#ff4444' })

--- a/src/scenes/level-types/MonsterManualLevel.ts
+++ b/src/scenes/level-types/MonsterManualLevel.ts
@@ -5,6 +5,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { loadProfile, saveProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class MonsterManualLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -30,8 +31,15 @@ export class MonsterManualLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a2a3a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.add.text(width / 2, 40, this.level.name, {

--- a/src/scenes/level-types/PotionBrewingLabLevel.ts
+++ b/src/scenes/level-types/PotionBrewingLabLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class PotionBrewingLabLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -37,8 +38,15 @@ export class PotionBrewingLabLevel extends Phaser.Scene {
 
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     // Level name

--- a/src/scenes/level-types/SillyChallengeLevel.ts
+++ b/src/scenes/level-types/SillyChallengeLevel.ts
@@ -6,6 +6,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface SillyEntity {
   word: string
@@ -51,8 +52,15 @@ export class SillyChallengeLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0xffaacc)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, {

--- a/src/scenes/level-types/SkeletonSwarmLevel.ts
+++ b/src/scenes/level-types/SkeletonSwarmLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Skeleton {
   word: string
@@ -58,8 +59,15 @@ export class SkeletonSwarmLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x222222)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, { fontSize: '22px', color: '#ff4444' })

--- a/src/scenes/level-types/SlimeSplittingLevel.ts
+++ b/src/scenes/level-types/SlimeSplittingLevel.ts
@@ -6,6 +6,7 @@ import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Slime {
   word: string
@@ -52,8 +53,15 @@ export class SlimeSplittingLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1e4a4a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     this.hpText = this.add.text(20, 20, `HP: ${'❤️'.repeat(this.playerHp)}`, { fontSize: '22px', color: '#ff4444' })

--- a/src/scenes/level-types/UndeadSiegeLevel.ts
+++ b/src/scenes/level-types/UndeadSiegeLevel.ts
@@ -6,6 +6,7 @@ import { getItem } from '../../data/items'
 import { getWordPool } from '../../utils/words'
 import { calcAccuracyStars, calcSpeedStars } from '../../utils/scoring'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 interface Undead {
   word: string
@@ -56,8 +57,15 @@ export class UndeadSiegeLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x1a2a3a)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
 
     // Castle

--- a/src/scenes/level-types/WoodlandFestivalLevel.ts
+++ b/src/scenes/level-types/WoodlandFestivalLevel.ts
@@ -5,6 +5,7 @@ import { TypingEngine } from '../../components/TypingEngine'
 import { loadProfile } from '../../utils/profile'
 import { getWordPool } from '../../utils/words'
 import { setupPause } from '../../utils/pauseSetup'
+import { generateAllCompanionTextures } from '../../art/companionsArt'
 
 export class WoodlandFestivalLevel extends Phaser.Scene {
   private level!: LevelConfig
@@ -37,8 +38,15 @@ export class WoodlandFestivalLevel extends Phaser.Scene {
     this.add.rectangle(width / 2, height / 2, width, height, 0x2d4a1e)
 
     const pProfileAvatar = loadProfile(this.profileSlot)
+    generateAllCompanionTextures(this)
     const avatarKey = this.textures.exists(pProfileAvatar?.avatarChoice || '') ? pProfileAvatar!.avatarChoice : 'avatar_0'
     this.add.image(100, height - 100, avatarKey).setScale(1.5).setDepth(5)
+
+    const pProfile = loadProfile(this.profileSlot)
+    const activeCompanion = pProfile?.activeCompanionId || pProfile?.activePetId
+    if (activeCompanion) {
+        this.add.image(180, height - 90, activeCompanion).setScale(1.5).setDepth(4)
+    }
 
     // HUD
     this.add.text(width / 2, 40, this.level.name, {


### PR DESCRIPTION
This PR introduces procedural pixel art generation for all companions and pets. It updates all gameplay scenes (levels and bosses) to visually render the active companion/pet next to the player, as well as showing their avatars on their respective cards in the Tavern and Stable scenes.

---
*PR created automatically by Jules for task [8608665881161301696](https://jules.google.com/task/8608665881161301696) started by @flamableconcrete*