### PR TITLE
Add Companion Level Up Notification

### DIFF
--- a/src/scenes/LevelResultScene.ts
+++ b/src/scenes/LevelResultScene.ts
@@ -3,7 +3,7 @@ import Phaser from 'phaser'
 import { ProfileData, LevelConfig } from '../types'
 import { loadProfile, saveProfile } from '../utils/profile'
 import { getItem } from '../data/items'
-import { calcXpReward, calcCharacterLevel } from '../utils/scoring'
+import { calcXpReward, calcCharacterLevel, calcCompanionLevel } from '../utils/scoring'
 import { getLevelsForWorld, ALL_LEVELS } from '../data/levels'
 
 interface ResultData {
@@ -41,6 +41,24 @@ export class LevelResultScene extends Phaser.Scene {
     const prevLevel = this.profile.characterLevel
     this.profile.xp += xpGained
     this.profile.characterLevel = calcCharacterLevel(this.profile.xp)
+
+    // Companion XP
+    const leveledUpCompanions: { name: string, level: number }[] = []
+
+    if (this.profile.activeCompanionId || this.profile.activePetId) {
+      const activeEntities = [...this.profile.companions, ...this.profile.pets]
+        .filter(c => c.id === this.profile.activeCompanionId || c.id === this.profile.activePetId)
+
+      for (const entity of activeEntities) {
+        const prevCompLevel = calcCompanionLevel(entity.xp)
+        entity.xp += xpGained
+        const newCompanionLevel = calcCompanionLevel(entity.xp)
+
+        if (newCompanionLevel > prevCompLevel) {
+          leveledUpCompanions.push({ name: entity.name, level: newCompanionLevel })
+        }
+      }
+    }
 
     // Award gold — 2 gold per enemy (word) defeated
     // Calculate gold based on bonus chance
@@ -135,10 +153,20 @@ export class LevelResultScene extends Phaser.Scene {
       fontSize: '24px', color: '#ffd700'
     }).setOrigin(0.5)
 
+    let yPos = 455
+
     if (this.profile.characterLevel > prevLevel) {
-      this.add.text(width / 2, 455, `Level Up! Now Level ${this.profile.characterLevel}`, {
+      this.add.text(width / 2, yPos, `Level Up! Now Level ${this.profile.characterLevel}`, {
         fontSize: '24px', color: '#ffd700'
       }).setOrigin(0.5)
+      yPos += 40
+    }
+
+    for (const comp of leveledUpCompanions) {
+      this.add.text(width / 2, yPos, `${comp.name} Leveled Up! Now Level ${comp.level}`, {
+        fontSize: '24px', color: '#aaffaa'
+      }).setOrigin(0.5)
+      yPos += 40
     }
 
     // Letter unlock banner
@@ -150,7 +178,7 @@ export class LevelResultScene extends Phaser.Scene {
 
     if (level.isBoss) {
       const soloStatus = this.resultData.companionUsed ? '❌ Companion Used' : '✅ Solo'
-      this.add.text(width / 2, 455, `Solo Scribe Status: ${soloStatus}`, {
+      this.add.text(width / 2, yPos, `Solo Scribe Status: ${soloStatus}`, {
         fontSize: '24px', color: this.resultData.companionUsed ? '#ff8888' : '#88ff88'
       }).setOrigin(0.5)
     }


### PR DESCRIPTION
Added a visual notification to the Level Result screen that triggers when an active companion or pet levels up, providing a more rewarding progression experience. Modified the rendering logic of the end-of-level notifications to stack dynamically, preventing overlaps.

---
*PR created automatically by Jules for task [3558450511526253220](https://jules.google.com/task/3558450511526253220) started by @flamableconcrete*