### PR TITLE
feat: clarify auto-strike functionality in companion scenes

### DIFF
--- a/src/scenes/StableScene.ts
+++ b/src/scenes/StableScene.ts
@@ -28,6 +28,10 @@ export class StableScene extends Phaser.Scene {
       fontSize: '22px', color: '#cccccc'
     }).setOrigin(0.5)
 
+    this.add.text(width / 2, 115, 'Pets provide auto-strikes that automatically destroy enemies.', {
+      fontSize: '14px', color: '#88aaff', fontStyle: 'italic'
+    }).setOrigin(0.5)
+
     const pets = this.profile.pets
     if (pets.length === 0) {
       this.add.text(width / 2, 300, 'No animal companions yet. Buy some below!', {

--- a/src/scenes/TavernScene.ts
+++ b/src/scenes/TavernScene.ts
@@ -28,6 +28,10 @@ export class TavernScene extends Phaser.Scene {
       fontSize: '22px', color: '#cccccc'
     }).setOrigin(0.5)
 
+    this.add.text(width / 2, 115, 'Companions provide auto-strikes that automatically destroy enemies.', {
+      fontSize: '14px', color: '#88aaff', fontStyle: 'italic'
+    }).setOrigin(0.5)
+
     const companions = this.profile.companions
     if (companions.length === 0) {
       this.add.text(width / 2, 200, 'No companions yet. Complete Guild Recruitment levels to recruit some!', {


### PR DESCRIPTION
- Added subtitle text explaining auto-strike in `TavernScene`
- Added subtitle text explaining auto-strike in `StableScene`
- Text explains that auto-strikes automatically destroy enemies, providing clear value prop for companions and pets.

---
*PR created automatically by Jules for task [10971007998945301717](https://jules.google.com/task/10971007998945301717) started by @flamableconcrete*