### PR TITLE
feat: display equipped items on player avatar

### DIFF
--- a/src/components/AvatarRenderer.ts
+++ b/src/components/AvatarRenderer.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser'
 import { AVATAR_CONFIGS, type AvatarConfig } from '../data/avatars'
+import type { EquipmentData } from '../types'
 
 const GRID = 16
 const PIXEL = 3
@@ -14,7 +15,7 @@ export class AvatarRenderer {
     }
   }
 
-  static generateOne(scene: Phaser.Scene, config: AvatarConfig): void {
+  static generateOne(scene: Phaser.Scene, config: AvatarConfig, equipment?: EquipmentData | null): void {
     const rt = scene.make.renderTexture({ width: WIDTH, height: HEIGHT }, false)
     const gfx = scene.make.graphics({}, false)
 
@@ -24,6 +25,10 @@ AvatarRenderer.drawHead(gfx, config.skinTone)
     AvatarRenderer.drawHair(gfx, config.hairStyle, config.hairColor)
     AvatarRenderer.drawBody(gfx, config)
     AvatarRenderer.drawAccessory(gfx, config.accessory, config.hairColor)
+
+    if (equipment) {
+      AvatarRenderer.drawEquipment(gfx, equipment)
+    }
 
     rt.draw(gfx)
     rt.saveTexture(config.id)
@@ -276,6 +281,35 @@ AvatarRenderer.drawHead(gfx, config.skinTone)
         AvatarRenderer.rect(gfx, 13, 5, 1, 2, 0x2255cc)
         AvatarRenderer.rect(gfx, 14, 6, 1, 2, 0x2255cc)
         break
+    }
+  }
+
+  // ── Equipment ─────────────────────────────────────────────
+
+  private static drawEquipment(
+    gfx: Phaser.GameObjects.Graphics,
+    equipment: EquipmentData
+  ): void {
+    // If we have a weapon, draw a simple sword in the right hand (left side of screen)
+    if (equipment.weapon) {
+      // Hilt at col 1, row 20
+      AvatarRenderer.rect(gfx, 1, 20, 2, 1, 0x8b4513) // brown crossguard
+      AvatarRenderer.rect(gfx, 1, 21, 1, 2, 0x8b4513) // brown handle
+      AvatarRenderer.px(gfx, 1, 23, 0xffd700)         // gold pommel
+      // Blade going up to row 10
+      AvatarRenderer.rect(gfx, 1, 10, 1, 10, 0xcccccc) // silver blade
+      // Optional tip
+      AvatarRenderer.px(gfx, 1, 9, 0xeeeeee)
+    }
+
+    // If we have armor, draw a shield or chestplate overlay
+    if (equipment.armor) {
+      // Draw a simple shield on the left hand (right side of screen)
+      // Base
+      AvatarRenderer.rect(gfx, 13, 17, 3, 5, 0x666666) // dark gray rim
+      AvatarRenderer.rect(gfx, 14, 18, 1, 3, 0xaa2222) // red center
+      // Point
+      AvatarRenderer.rect(gfx, 14, 22, 1, 1, 0x666666) // point
     }
   }
 }

--- a/src/scenes/AvatarCustomizerScene.ts
+++ b/src/scenes/AvatarCustomizerScene.ts
@@ -146,15 +146,16 @@ export class AvatarCustomizerScene extends Phaser.Scene {
 
     const slotSpacing = 80
     const startX = centerX - (4 * slotSpacing) / 2
+    const profile = loadProfile(this.slot)
 
     for (let i = 0; i < 5; i++) {
       const sx = startX + i * slotSpacing
-      this.drawOneOutfitSlot(sx, y, i)
+      this.drawOneOutfitSlot(sx, y, i, profile)
     }
   }
 
-  private drawOneOutfitSlot(x: number, y: number, index: number) {
-    const profile = this.getProfile()
+  private drawOneOutfitSlot(x: number, y: number, index: number, profileParams?: any) {
+    const profile = this.getProfile() || profileParams
     const outfit = profile?.savedOutfits?.[index] ?? null
 
     // Frame
@@ -165,7 +166,7 @@ export class AvatarCustomizerScene extends Phaser.Scene {
     if (outfit) {
       const thumbKey = `outfit_thumb_${this.slot}_${index}_${Date.now()}`
       const thumbConfig = { ...outfit, id: thumbKey }
-      AvatarRenderer.generateOne(this, thumbConfig)
+      AvatarRenderer.generateOne(this, thumbConfig, profile?.equipment)
       const thumb = this.add.image(x, y, thumbKey).setDisplaySize(24, 48)
       this.outfitSlotObjects.push(thumb)
     } else {
@@ -327,7 +328,8 @@ export class AvatarCustomizerScene extends Phaser.Scene {
 
   private renderPreview() {
     this.config.id = `custom_${Date.now()}`
-    AvatarRenderer.generateOne(this, this.config)
+    const p = loadProfile(this.slot)
+    AvatarRenderer.generateOne(this, this.config, p?.equipment)
     this.previewImage.setTexture(this.config.id)
   }
 

--- a/src/scenes/CharacterScene.ts
+++ b/src/scenes/CharacterScene.ts
@@ -264,7 +264,7 @@ export class CharacterScene extends Phaser.Scene {
     if (outfit) {
       const thumbKey = `tab_outfit_${this.profileSlot}_${index}_${Date.now()}`
       const thumbConfig = { ...outfit, id: thumbKey }
-      AvatarRenderer.generateOne(this, thumbConfig)
+      AvatarRenderer.generateOne(this, thumbConfig, this.profile.equipment)
       const thumb = this.add.image(x, y, thumbKey).setDisplaySize(20, 40)
       this.container.add(thumb)
     } else {
@@ -382,7 +382,7 @@ export class CharacterScene extends Phaser.Scene {
 
   private renderTabPreview() {
     this.avatarConfig.id = `custom_${Date.now()}`
-    AvatarRenderer.generateOne(this, this.avatarConfig)
+    AvatarRenderer.generateOne(this, this.avatarConfig, this.profile.equipment)
   }
 
   private addSectionTitle(container: Phaser.GameObjects.Container, y: number, text: string) {
@@ -519,6 +519,19 @@ export class CharacterScene extends Phaser.Scene {
         this.profile.equipment[slot] = item ? item.id : null
         saveProfile(this.profileSlot, this.profile)
         this.hideItemSelection()
+
+        // Re-generate avatar preview when equipment changes
+        if (this.avatarConfig) {
+          this.renderTabPreview()
+          this.avatarPreviewImage.setTexture(this.avatarConfig.id)
+        }
+
+        // Invalidate global map avatar texture so it updates next time OverlandMapScene loads
+        if (this.profile.avatarConfig && this.profile.avatarConfig.id) {
+          if (this.textures.exists(this.profile.avatarConfig.id)) {
+            this.textures.remove(this.profile.avatarConfig.id)
+          }
+        }
       })
       this.selectionContainer.add(bg)
 

--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -126,7 +126,7 @@ export class OverlandMapScene extends Phaser.Scene {
 
     // Regenerate custom avatar texture if needed
     if (this.profile.avatarConfig && !this.textures.exists(this.profile.avatarConfig.id)) {
-      AvatarRenderer.generateOne(this, this.profile.avatarConfig)
+      AvatarRenderer.generateOne(this, this.profile.avatarConfig, this.profile.equipment)
     }
     const avatarTexture = (this.profile.avatarConfig?.id && this.textures.exists(this.profile.avatarConfig.id))
       ? this.profile.avatarConfig.id

--- a/src/scenes/ProfileSelectScene.ts
+++ b/src/scenes/ProfileSelectScene.ts
@@ -93,7 +93,7 @@ export class ProfileSelectScene extends Phaser.Scene {
     // Ensure custom avatar is generated if it exists
     if (profile.avatarConfig && profile.avatarConfig.id) {
       if (!this.textures.exists(profile.avatarConfig.id)) {
-        AvatarRenderer.generateOne(this, profile.avatarConfig);
+        AvatarRenderer.generateOne(this, profile.avatarConfig, profile.equipment);
       }
       const avatarKey = profile.avatarConfig.id;
       this.add.image(avatarX, y, avatarKey).setDisplaySize(36, 72);


### PR DESCRIPTION
This PR makes it so that when a player equips a weapon or armor item, they can visually see a representation of it (a basic sword and/or shield) on their avatar. It updates `AvatarRenderer` and plumbs the optional equipment parameter down to everywhere the avatar is procedurally generated. Changing equipment in the `CharacterScene` now correctly triggers a re-draw and invalidates the global cached texture so it shows up right away.

---
*PR created automatically by Jules for task [15461342306685502637](https://jules.google.com/task/15461342306685502637) started by @flamableconcrete*