### PR TITLE
feat: Rotating Shop Inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@vitest/ui": "^4.0.18",
         "jsdom": "^28.1.0",
+        "playwright": "^1.58.2",
         "typescript": "~5.9.3",
         "vite": "^7.3.1",
         "vitest": "^4.0.18"
@@ -1651,6 +1652,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@vitest/ui": "^4.0.18",
     "jsdom": "^28.1.0",
+    "playwright": "^1.58.2",
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"

--- a/src/scenes/LevelResultScene.ts
+++ b/src/scenes/LevelResultScene.ts
@@ -5,6 +5,7 @@ import { loadProfile, saveProfile } from '../utils/profile'
 import { getItem } from '../data/items'
 import { calcXpReward, calcCharacterLevel } from '../utils/scoring'
 import { getLevelsForWorld, ALL_LEVELS } from '../data/levels'
+import { rotateShopItems } from '../utils/shop'
 
 interface ResultData {
   level: LevelConfig
@@ -94,6 +95,14 @@ export class LevelResultScene extends Phaser.Scene {
     // Letter unlock if mini-boss
     if (level.miniBossUnlocksLetter && !this.profile.unlockedLetters.includes(level.miniBossUnlocksLetter)) {
       this.profile.unlockedLetters.push(level.miniBossUnlocksLetter)
+    }
+
+    // Rotate shop items if a mini-boss or boss was defeated
+    if (level.isMiniBoss || level.isBoss) {
+      if (!this.profile.currentShopItemIds) {
+        this.profile.currentShopItemIds = []
+      }
+      this.profile.currentShopItemIds = rotateShopItems(this.profile.currentShopItemIds, this.profile.ownedItemIds || [])
     }
 
     saveProfile(this.resultData.profileSlot, this.profile)

--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -46,7 +46,13 @@ export class ShopScene extends Phaser.Scene {
         fontSize: '24px', color: '#ffffff', fontStyle: 'bold'
       }).setOrigin(0.5)
 
-      const catItems = ITEMS.filter(item => item.slot === cat && item.goldCost > 0)
+      const catItems = ITEMS.filter(item =>
+        item.slot === cat &&
+        item.goldCost > 0 &&
+        this.profile.currentShopItemIds?.includes(item.id) &&
+        !this.profile.ownedItemIds.includes(item.id)
+      )
+
       catItems.forEach((item, j) => {
         const cy = 160 + j * 100
         this.renderItemCard(cx, cy, item)
@@ -55,18 +61,23 @@ export class ShopScene extends Phaser.Scene {
   }
 
   private renderItemCard(x: number, y: number, item: ItemData) {
-    const isOwned = this.profile.ownedItemIds.includes(item.id)
     const canAfford = (this.profile.gold ?? 0) >= item.goldCost
 
-    const bgColor = isOwned ? 0x223322 : canAfford ? 0x333366 : 0x2a2a2a
+    const bgColor = canAfford ? 0x333366 : 0x2a2a2a
     const bg = this.add.rectangle(x, y, 380, 90, bgColor)
       .setStrokeStyle(2, 0x4e4e6a)
 
-    if (!isOwned && canAfford) {
+    if (canAfford) {
       bg.setInteractive({ useHandCursor: true })
       bg.on('pointerdown', () => {
         this.profile.gold -= item.goldCost
         this.profile.ownedItemIds.push(item.id)
+
+        // Remove item from shop pool upon purchase
+        if (this.profile.currentShopItemIds) {
+          this.profile.currentShopItemIds = this.profile.currentShopItemIds.filter(id => id !== item.id)
+        }
+
         saveProfile(this.profileSlot, this.profile)
         this.scene.restart({ profileSlot: this.profileSlot })
       })
@@ -85,8 +96,8 @@ export class ShopScene extends Phaser.Scene {
     this.add.text(x - 180, y - 5, effectStr.trim(), { fontSize: '12px', color: '#00ff00' }).setOrigin(0, 0.5)
     this.add.text(x - 180, y + 15, item.description, { fontSize: '11px', color: '#aaaaaa', wordWrap: { width: 360 } }).setOrigin(0, 0)
 
-    const statusText = isOwned ? 'OWNED' : `${item.goldCost} Gold`
-    const statusColor = isOwned ? '#44ff44' : canAfford ? '#ffd700' : '#ff4444'
+    const statusText = `${item.goldCost} Gold`
+    const statusColor = canAfford ? '#ffd700' : '#ff4444'
     this.add.text(x + 180, y - 30, statusText, { fontSize: '16px', color: statusColor, fontStyle: 'bold' }).setOrigin(1, 0.5)
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface ProfileData {
   worldMasteryRewards: string[]
   bossWeaknessKnown: string | null
   gameMode: 'regular' | 'advanced'
+  currentShopItemIds?: string[]
   gold: number
   showFingerHints: boolean
   avatarConfig?: AvatarConfig

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,4 +1,5 @@
 import { ProfileData } from '../types'
+import { getInitialShopItems } from './shop'
 
 const HOME_ROW: string[] = ['a', 's', 'd', 'f', 'j', 'k', 'l']
 const KEY = (slot: number) => `kq_profile_${slot}`
@@ -33,6 +34,7 @@ export function createProfile(playerName: string, avatarChoice = 'knight', avata
     worldMasteryRewards: [],
     bossWeaknessKnown: null,
     gameMode: 'regular' as const,
+    currentShopItemIds: getInitialShopItems([]),
     gold: 0,
     showFingerHints: true,
   }
@@ -50,6 +52,9 @@ export function loadProfile(slot: number): ProfileData | null {
     if (!data.gameMode) data.gameMode = 'regular'
     if (data.gold === undefined) data.gold = 0
     if (data.showFingerHints === undefined) data.showFingerHints = true
+    if (!data.currentShopItemIds) {
+      data.currentShopItemIds = getInitialShopItems(data.ownedItemIds || [])
+    }
     return data
   } catch {
     return null

--- a/src/utils/shop.ts
+++ b/src/utils/shop.ts
@@ -1,0 +1,76 @@
+import { ITEMS } from '../data/items'
+
+const ITEMS_PER_CATEGORY = 3
+
+export function getInitialShopItems(ownedItemIds: string[]): string[] {
+  const shopItems: string[] = []
+  const categories: ('weapon' | 'armor' | 'accessory')[] = ['weapon', 'armor', 'accessory']
+
+  for (const cat of categories) {
+    const availableItems = ITEMS.filter(
+      (item) => item.slot === cat && item.goldCost > 0 && !ownedItemIds.includes(item.id)
+    )
+
+    // Shuffle and pick
+    const shuffled = availableItems.sort(() => 0.5 - Math.random())
+    const selected = shuffled.slice(0, ITEMS_PER_CATEGORY).map((item) => item.id)
+    shopItems.push(...selected)
+  }
+
+  return shopItems
+}
+
+export function rotateShopItems(currentShopItemIds: string[], ownedItemIds: string[]): string[] {
+  // We want to replace 1-2 items per restock (let's say 1-2 items total across all categories to simulate a partial restock, or 1-2 per category?
+  // "each mini boss that is defeated should change 1-2 items available in the shop" implies 1-2 items total)
+  const itemsToReplaceCount = Math.floor(Math.random() * 2) + 1 // 1 or 2 items
+
+  const newShopItemIds = [...currentShopItemIds]
+
+  // Filter out owned items first (if they somehow are still in the shop array)
+  // This effectively removes any purchased items from the current shop state
+  const unownedCurrentShopItems = newShopItemIds.filter((id) => !ownedItemIds.includes(id))
+
+  // If we have fewer items than we should (due to purchases), we should replenish up to the limit per category
+  const categories: ('weapon' | 'armor' | 'accessory')[] = ['weapon', 'armor', 'accessory']
+
+  for (const cat of categories) {
+    const currentCatItems = unownedCurrentShopItems.filter(
+      (id) => ITEMS.find((item) => item.id === id)?.slot === cat
+    )
+
+    // How many items are missing in this category?
+    const missingCount = ITEMS_PER_CATEGORY - currentCatItems.length
+    if (missingCount > 0) {
+      const availableItems = ITEMS.filter(
+        (item) => item.slot === cat && item.goldCost > 0 && !ownedItemIds.includes(item.id) && !unownedCurrentShopItems.includes(item.id)
+      )
+      const shuffled = availableItems.sort(() => 0.5 - Math.random())
+      const selected = shuffled.slice(0, missingCount).map((item) => item.id)
+      unownedCurrentShopItems.push(...selected)
+    }
+  }
+
+  // Now perform the 1-2 item rotation
+  // Pick random indices to replace
+  let replaceableIndices = [...Array(unownedCurrentShopItems.length).keys()]
+  replaceableIndices = replaceableIndices.sort(() => 0.5 - Math.random()).slice(0, itemsToReplaceCount)
+
+  for (const index of replaceableIndices) {
+    const itemIdToReplace = unownedCurrentShopItems[index]
+    const itemToReplace = ITEMS.find((i) => i.id === itemIdToReplace)
+
+    if (itemToReplace) {
+      const availableItems = ITEMS.filter(
+        (item) => item.slot === itemToReplace.slot && item.goldCost > 0 && !ownedItemIds.includes(item.id) && !unownedCurrentShopItems.includes(item.id)
+      )
+
+      if (availableItems.length > 0) {
+        const newItem = availableItems[Math.floor(Math.random() * availableItems.length)]
+        unownedCurrentShopItems[index] = newItem.id
+      }
+    }
+  }
+
+  return unownedCurrentShopItems
+}


### PR DESCRIPTION
Implemented a dynamic rotating shop inventory system. The shop will now always carry a fixed set of 3 unowned items per category (weapon, armor, accessory). Whenever the player defeats a boss or mini-boss, the inventory rotates, replacing 1 or 2 items with other available, unowned items of the same category. Owned items are no longer shown in the shop.

---
*PR created automatically by Jules for task [3645268641820071746](https://jules.google.com/task/3645268641820071746) started by @flamableconcrete*