### PR TITLE
fix: Boss level unlocking logic bug in OverlandMapScene.ts

### DIFF
--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -214,8 +214,7 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
       const r = this.profile.levelResults[id]
       return sum + (r ? r.accuracyStars + r.speedStars : 0)
     }, 0)
-    const avg = total / levelIds.length
-    return avg >= minCombinedStars
+    return total >= minCombinedStars
   }
 
   private drawNodes(levels: LevelConfig[], nodePositions: NodePosition[]) {
@@ -320,7 +319,7 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
           repeat: -1,
         })
         const gate = level.bossGate!
-        this.add.text(pos.x, pos.y + 24, `Need avg ${gate.minCombinedStars}★`, {
+        this.add.text(pos.x, pos.y + 24, `Need ${gate.minCombinedStars}★ total`, {
           fontSize: '10px', color: '#ff8888'
         }).setOrigin(0.5).setDepth(2000)
       }


### PR DESCRIPTION
The debug mode "Unlock All Levels" wasn't unlocking some boss levels
because `meetsGate` in `OverlandMapScene.ts` was comparing an average
star count per level against the `minCombinedStars` requirement.
The average could only reach 10, meaning bosses requiring more than
10 combined stars could never unlock.

This changes the checking logic to compare the total accumulated
stars against `minCombinedStars`, correctly satisfying the requirement.
Also updated the UI text label to "Need X★ total" to be clearer.

---
*PR created automatically by Jules for task [15915711714371554851](https://jules.google.com/task/15915711714371554851) started by @flamableconcrete*