### PR TITLE
feat: Enhance Boss Node visuals and progression mechanics

### DIFF
--- a/src/scenes/LevelResultScene.ts
+++ b/src/scenes/LevelResultScene.ts
@@ -101,7 +101,7 @@ export class LevelResultScene extends Phaser.Scene {
     this.unlockNextLevels(level)
 
     // Letter unlock if mini-boss
-    if (level.miniBossUnlocksLetter && !this.profile.unlockedLetters.includes(level.miniBossUnlocksLetter)) {
+    if (level.isMiniBoss && level.miniBossUnlocksLetter && !this.profile.unlockedLetters.includes(level.miniBossUnlocksLetter)) {
       this.profile.unlockedLetters.push(level.miniBossUnlocksLetter)
     }
 
@@ -169,7 +169,7 @@ export class LevelResultScene extends Phaser.Scene {
     }
 
     // Letter unlock banner
-    if (level.miniBossUnlocksLetter) {
+    if (level.isMiniBoss && level.miniBossUnlocksLetter) {
       this.add.text(width / 2, yPos, `The letter "${level.miniBossUnlocksLetter.toUpperCase()}" has been restored!`, {
         fontSize: '26px', color: '#aaaaff'
       }).setOrigin(0.5)
@@ -184,7 +184,7 @@ export class LevelResultScene extends Phaser.Scene {
     }).setOrigin(0.5).setInteractive({ useHandCursor: true })
 
     const doContinue = () => {
-      if (this.resultData.level.miniBossUnlocksLetter && passed) {
+      if (this.resultData.level.isMiniBoss && this.resultData.level.miniBossUnlocksLetter && passed) {
         this.scene.start('Cutscene', {
           letter: this.resultData.level.miniBossUnlocksLetter,
           title: this.resultData.level.rewards.title ?? 'A new letter awakens!',
@@ -237,6 +237,15 @@ export class LevelResultScene extends Phaser.Scene {
       const next = worldLevels[idx + 1]
       if (!this.profile.unlockedLevelIds.includes(next.id)) {
         this.profile.unlockedLevelIds.push(next.id)
+      }
+    } else if (completedLevel.isBoss) {
+      // If this is the last level (a boss), unlock the first level of the next world
+      const nextWorldLevels = getLevelsForWorld(completedLevel.world + 1)
+      if (nextWorldLevels && nextWorldLevels.length > 0) {
+        const nextWorldFirstLevel = nextWorldLevels[0]
+        if (!this.profile.unlockedLevelIds.includes(nextWorldFirstLevel.id)) {
+          this.profile.unlockedLevelIds.push(nextWorldFirstLevel.id)
+        }
       }
     }
   }

--- a/src/scenes/OverlandMapScene.ts
+++ b/src/scenes/OverlandMapScene.ts
@@ -230,11 +230,14 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
         : unlocked && !gated ? 0xffffff
         : 0x444444
 
+      // 2.5x larger for world bosses
+      const baseScale = level.isBoss ? 3.75 : 1.5
+
       // Base oval
-      this.add.ellipse(pos.x, pos.y + 16, 64, 24, 0x8b6b3a).setDepth(998)
+      this.add.ellipse(pos.x, pos.y + (16 * (baseScale / 1.5)), 64 * (baseScale / 1.5), 24 * (baseScale / 1.5), 0x8b6b3a).setDepth(998)
 
       const nodeFrame = level.isBoss ? COMMON_FRAMES.nodeBoss : level.isMiniBoss ? COMMON_FRAMES.nodeMiniBoss : COMMON_FRAMES.nodeLevel
-      const nodeSprite = this.add.sprite(pos.x, pos.y, 'map-common', nodeFrame).setTint(color).setDepth(1000).setScale(1.5)
+      const nodeSprite = this.add.sprite(pos.x, pos.y, 'map-common', nodeFrame).setTint(color).setDepth(1000).setScale(baseScale)
 
       if (unlocked && !gated) {
         nodeSprite.setInteractive({ useHandCursor: true })
@@ -243,8 +246,8 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
         nodeSprite.on('pointerover', () => {
           this.tweens.add({
             targets: nodeSprite,
-            scaleX: 1.5 * 1.15,
-            scaleY: 1.5 * 1.15,
+            scaleX: baseScale * 1.15,
+            scaleY: baseScale * 1.15,
             duration: 150,
             ease: 'Back.easeOut',
           })
@@ -252,7 +255,7 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
           this.glowRect?.destroy()
           this.glowRect = this.add.rectangle(
             pos.x, pos.y,
-            (nodeSprite.width * 1.5) + 12, (nodeSprite.height * 1.5) + 12,
+            (nodeSprite.width * baseScale) + 12, (nodeSprite.height * baseScale) + 12,
             0xffffff, 0.2
           ).setDepth(nodeSprite.depth - 1)
           this.showTooltip(level, pos)
@@ -261,8 +264,8 @@ this.avatar = this.add.sprite(startPos.x, startPos.y, avatarTexture).setDepth(10
         nodeSprite.on('pointerout', () => {
           this.tweens.add({
             targets: nodeSprite,
-            scaleX: 1.5,
-            scaleY: 1.5,
+            scaleX: baseScale,
+            scaleY: baseScale,
             duration: 150,
             ease: 'Sine.easeIn',
           })


### PR DESCRIPTION
Implemented the feature requests to make boss nodes visually distinct and to fix progression bugs related to bosses unlocking new letters and new worlds.
- Boss nodes on the map are now explicitly scaled to be 2.5x larger than standard level and mini-boss nodes.
- When a level marked as `isBoss` is completed, the first level of the subsequent world is now automatically unlocked.
- Mini boss letter unlocks now explicitly check for the `isMiniBoss` flag before triggering, ensuring other node types don't trigger the letter unlock cutscene and profile updates.

---
*PR created automatically by Jules for task [5426348256146912945](https://jules.google.com/task/5426348256146912945) started by @flamableconcrete*