### PR TITLE
Remove goblin limit in Goblin Whacker levels

### DIFF
--- a/src/scenes/level-types/GoblinWhackerLevel.ts
+++ b/src/scenes/level-types/GoblinWhackerLevel.ts
@@ -46,7 +46,6 @@ export class GoblinWhackerLevel extends Phaser.Scene {
   private gameMode: 'regular' | 'advanced' = 'regular'
   private readonly BATTLE_X = 300        // where lead goblin stops in regular mode
   private readonly GOBLIN_SPACING = 120  // horizontal gap between queued goblins
-  private readonly MAX_VISIBLE_QUEUE = 4 // max goblins on screen at once in regular mode
   private pathY = 0                      // fixed Y for all goblins (set in create)
   private wrongKeyCount = 0
   private nextAttackThreshold = 0
@@ -196,7 +195,6 @@ export class GoblinWhackerLevel extends Phaser.Scene {
 
   private spawnGoblin() {
     if (this.finished || this.wordQueue.length === 0) return
-    if (this.gameMode === 'regular' && this.goblins.length >= this.MAX_VISIBLE_QUEUE) return
     // Don't spawn if the last goblin is still near the right edge (prevents overlap)
     const lastGoblin = this.goblins[this.goblins.length - 1]
     if (lastGoblin && lastGoblin.x > this.scale.width - this.GOBLIN_SPACING) return


### PR DESCRIPTION
Removed the max limit of 4 goblins in regular mode for Goblin Whacker levels. They will now spawn as long as there is horizontal room on the screen based on their specified spacing.

---
*PR created automatically by Jules for task [364091073160272871](https://jules.google.com/task/364091073160272871) started by @flamableconcrete*