### PR TITLE
feat: Standardize and enlarge Back buttons across UI menus

### DIFF
--- a/src/scenes/AvatarCustomizerScene.ts
+++ b/src/scenes/AvatarCustomizerScene.ts
@@ -123,9 +123,9 @@ export class AvatarCustomizerScene extends Phaser.Scene {
     confirmBox.on('pointerdown', () => this.handleConfirm())
 
     // Back button
-    const backText = this.add.text(40, height - 55, '< Back', {
-      fontSize: '20px', color: '#888888', fontFamily: MONO_FONT
-    }).setOrigin(0, 0.5).setInteractive({ useHandCursor: true })
+    const backText = this.add.text(60, 40, '← BACK', {
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }, fontFamily: MONO_FONT
+    }).setInteractive({ useHandCursor: true })
     backText.on('pointerdown', () => {
       if (this.returnTo === 'Settings') {
         this.scene.start('Settings', { profileSlot: this.slot })

--- a/src/scenes/LevelIntroScene.ts
+++ b/src/scenes/LevelIntroScene.ts
@@ -71,6 +71,15 @@ export class LevelIntroScene extends Phaser.Scene {
       ease: 'Sine.easeInOut',
     })
 
+    const back = this.add.text(60, 40, '← BACK', {
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }
+    }).setInteractive({ useHandCursor: true })
+
+    back.on('pointerdown', (_pointer: Phaser.Input.Pointer, _localX: number, _localY: number, event: Phaser.Types.Input.EventData) => {
+      event.stopPropagation()
+      this.scene.start('OverlandMap', { profileSlot: this.profileSlot })
+    })
+
     this.input.keyboard?.once('keydown-SPACE', this.enter, this)
     this.input.once('pointerdown', this.enter, this)
   }

--- a/src/scenes/ProfileSelectScene.ts
+++ b/src/scenes/ProfileSelectScene.ts
@@ -74,14 +74,9 @@ export class ProfileSelectScene extends Phaser.Scene {
     })
 
     // Back button
-    const backW = 120
-    const backH = 40
-    const backX = 80
-    const backY = height - 40
-    this.drawPixelPanel(backX, backY, backW, backH, 0x2a2a4a, 0x5555aa)
-    const back = this.add.text(backX, backY, '< BACK', {
-      fontSize: '18px', color: '#aaaaaa', fontFamily: MONO_FONT
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true })
+    const back = this.add.text(60, 40, '← BACK', {
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }, fontFamily: MONO_FONT
+    }).setInteractive({ useHandCursor: true })
     back.on('pointerdown', () => this.scene.start('MainMenu'))
   }
 

--- a/src/scenes/ShopScene.ts
+++ b/src/scenes/ShopScene.ts
@@ -32,7 +32,7 @@ export class ShopScene extends Phaser.Scene {
     }).setOrigin(1, 0.5)
 
     const back = this.add.text(60, 40, '← BACK', {
-      fontSize: '20px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 10, y: 5 }
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }
     }).setInteractive({ useHandCursor: true })
 
     back.on('pointerdown', () => {

--- a/src/scenes/StableScene.ts
+++ b/src/scenes/StableScene.ts
@@ -87,9 +87,9 @@ export class StableScene extends Phaser.Scene {
       })
     })
 
-    const back = this.add.text(width / 2, height - 40, '[ Back to Map ]', {
-      fontSize: '24px', color: '#ffffff'
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true })
+    const back = this.add.text(60, 40, '← BACK', {
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }
+    }).setInteractive({ useHandCursor: true })
     back.on('pointerdown', () => {
       this.scene.start('OverlandMap', { profileSlot: this.profileSlot })
     })

--- a/src/scenes/TavernScene.ts
+++ b/src/scenes/TavernScene.ts
@@ -88,9 +88,9 @@ export class TavernScene extends Phaser.Scene {
       })
     })
 
-    const back = this.add.text(width / 2, height - 40, '[ Back to Map ]', {
-      fontSize: '24px', color: '#ffffff'
-    }).setOrigin(0.5).setInteractive({ useHandCursor: true })
+    const back = this.add.text(60, 40, '← BACK', {
+      fontSize: '28px', color: '#ffffff', backgroundColor: '#4e4e6a', padding: { x: 20, y: 10 }
+    }).setInteractive({ useHandCursor: true })
     back.on('pointerdown', () => {
       this.scene.start('OverlandMap', { profileSlot: this.profileSlot })
     })


### PR DESCRIPTION
This PR standardizes the "Back" button across all major non-gameplay menu screens. The new button is larger, more prominent, and consistently placed in the top-left corner (`x: 60, y: 40`).

Changes:
- **ShopScene**: Increased button font size and padding.
- **StableScene & TavernScene**: Replaced the center-bottom "[ Back to Map ]" buttons with the new standardized top-left button.
- **LevelIntroScene**: Added the missing back button, allowing players to back out to the overland map before starting a level. Includes event propagation handling so clicking the button doesn't trigger the global "start level" click event.
- **ProfileSelectScene & AvatarCustomizerScene**: Moved the back buttons from the bottom to the top-left corner and updated their styles to match the new global standard.

---
*PR created automatically by Jules for task [2092631226254775245](https://jules.google.com/task/2092631226254775245) started by @flamableconcrete*