### PR TITLE
Fix missing map nodes for world 2-5

### DIFF
--- a/src/data/maps/world2.ts
+++ b/src/data/maps/world2.ts
@@ -270,8 +270,14 @@ function buildPathSegments(): PathSegment[] {
     { cx: 200, cy: 220 },
     // mb3 → l8: upward
     { cx: 180, cy: 160 },
-    // l8 → boss: final approach
+    // l8 → l9: curve slightly
     { cx: 130, cy: 100 },
+    // l9 → l10: continue approach
+    { cx: 180, cy: 60 },
+    // l10 → mb4: nearing the end
+    { cx: 240, cy: 40 },
+    // mb4 → boss: final approach
+    { cx: 320, cy: 20 },
   ]
 }
 
@@ -338,7 +344,10 @@ export const WORLD2_MAP: WorldMapData = {
     { x: 240, y: 270 },  // l7
     { x: 150, y: 210 },  // mb3
     { x: 200, y: 140 },  // l8
-    { x: 110, y: 80 },   // boss
+    { x: 160, y: 90 },   // l9
+    { x: 220, y: 50 },   // l10
+    { x: 280, y: 30 },   // mb4
+    { x: 380, y: 20 },   // boss
   ],
 
   specialNodes: {

--- a/src/data/maps/world3.ts
+++ b/src/data/maps/world3.ts
@@ -275,8 +275,12 @@ function buildPathSegments(): PathSegment[] {
     { cx: 520, cy: 170 },
     // mb3 → l8: upward
     { cx: 620, cy: 120 },
-    // l8 → boss: final climb
+    // l8 → l9: curve left
     { cx: 600, cy: 60 },
+    // l9 → mb4: right upward
+    { cx: 720, cy: 40 },
+    // mb4 → boss: final climb
+    { cx: 800, cy: 20 },
   ]
 }
 
@@ -343,7 +347,9 @@ export const WORLD3_MAP: WorldMapData = {
     { x: 400, y: 210 },  // l7
     { x: 560, y: 150 },  // mb3
     { x: 640, y: 100 },  // l8
-    { x: 580, y: 50 },   // boss — summit
+    { x: 680, y: 60 },   // l9
+    { x: 760, y: 30 },   // mb4
+    { x: 860, y: 20 },   // boss — summit
   ],
 
   specialNodes: {

--- a/src/data/maps/world4.ts
+++ b/src/data/maps/world4.ts
@@ -296,8 +296,12 @@ function buildPathSegments(): PathSegment[] {
     { cx: 1180, cy: 440 },
     // mb3 → l8: left and up
     { cx: 1100, cy: 300 },
-    // l8 → boss: final right
-    { cx: 1180, cy: 200 },
+    // l8 → l9: curve up
+    { cx: 1100, cy: 240 },
+    // l9 → mb4: right curve
+    { cx: 1140, cy: 180 },
+    // mb4 → boss: final right
+    { cx: 1220, cy: 140 },
   ]
 }
 
@@ -364,7 +368,9 @@ export const WORLD4_MAP: WorldMapData = {
     { x: 1160, y: 360 }, // l7
     { x: 1180, y: 470 }, // mb3
     { x: 1080, y: 280 }, // l8
-    { x: 1200, y: 180 }, // boss
+    { x: 1060, y: 210 }, // l9
+    { x: 1120, y: 150 }, // mb4
+    { x: 1260, y: 120 }, // boss
   ],
 
   specialNodes: {

--- a/src/data/maps/world5.ts
+++ b/src/data/maps/world5.ts
@@ -282,8 +282,10 @@ function buildPathSegments(): PathSegment[] {
     { cx: 620, cy: 160 },
     // mb3 → l8: up
     { cx: 680, cy: 110 },
-    // l8 → boss: final ascent to summit
-    { cx: 640, cy: 50 },
+    // l8 → mb4: right-up
+    { cx: 720, cy: 70 },
+    // mb4 → boss: final ascent to summit
+    { cx: 760, cy: 30 },
   ]
 }
 
@@ -350,7 +352,8 @@ export const WORLD5_MAP: WorldMapData = {
     { x: 740, y: 190 },  // l7
     { x: 640, y: 140 },  // mb3
     { x: 700, y: 90 },   // l8
-    { x: 640, y: 40 },   // boss — tower summit
+    { x: 760, y: 60 },   // mb4
+    { x: 840, y: 20 },   // boss — tower summit
   ],
 
   specialNodes: {


### PR DESCRIPTION
The previous iteration of the code silently omitted drawing map nodes for levels that were at the end of the worlds list, because the map data had arrays of length 12 while worlds had 13, 14, or 15 levels.

This commit updates the `nodePositions` and `pathSegments` configurations in `src/data/maps/world{2,3,4,5}.ts` to correctly match the count of level configurations. It continues the left-to-right ascending map patterns and places the bosses correctly.

---
*PR created automatically by Jules for task [15061083874830157699](https://jules.google.com/task/15061083874830157699) started by @flamableconcrete*