### PR TITLE
fix: Update character avatar visuals when equipment changes

### DIFF
--- a/src/scenes/CharacterScene.ts
+++ b/src/scenes/CharacterScene.ts
@@ -237,6 +237,9 @@ export class CharacterScene extends Phaser.Scene {
       this.profile.avatarConfig = JSON.parse(JSON.stringify(this.avatarConfig))
       this.profile.avatarChoice = this.avatarConfig.id
       saveProfile(this.profileSlot, this.profile)
+      if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
+        this.textures.remove(this.profile.avatarConfig.id)
+      }
       this.avatarDirty = true
 
       saveBg.setFillStyle(0x44ff44)
@@ -435,6 +438,10 @@ export class CharacterScene extends Phaser.Scene {
       unequipBtn.on('pointerdown', () => {
         this.profile.equipment[slot] = null
         saveProfile(this.profileSlot, this.profile)
+        if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
+          this.textures.remove(this.profile.avatarConfig.id)
+        }
+        this.avatarDirty = true
         this.drawActiveTab()
       })
       container.add(unequipBtn)
@@ -507,6 +514,10 @@ export class CharacterScene extends Phaser.Scene {
         if (!isEquipped) {
           this.profile.equipment[slot] = item.id
           saveProfile(this.profileSlot, this.profile)
+          if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
+            this.textures.remove(this.profile.avatarConfig.id)
+          }
+          this.avatarDirty = true
           this.drawActiveTab()
         }
       })


### PR DESCRIPTION
The player's character avatar was not properly updating on the world map and in levels after equipping items in the Character screen. This change removes the old cached texture and triggers a global update by setting `avatarDirty = true` when equipment is changed (equipped/unequipped) or when saving an outfit, properly regenerating the texture with the new items across all scenes.

---
*PR created automatically by Jules for task [18182871717697838565](https://jules.google.com/task/18182871717697838565) started by @flamableconcrete*