### PR TITLE
Fix WebGL crash when equipping items in Character Scene

### DIFF
--- a/src/scenes/CharacterScene.ts
+++ b/src/scenes/CharacterScene.ts
@@ -18,6 +18,7 @@ export class CharacterScene extends Phaser.Scene {
   private avatarConfig!: AvatarConfig
   private avatarPreviewImage!: Phaser.GameObjects.Image
   private avatarDirty = false
+  private originalAvatarId: string | null = null
 
   constructor() {
     super('Character')
@@ -29,6 +30,7 @@ export class CharacterScene extends Phaser.Scene {
 
     // Initialize avatar config once from profile
     if (this.profile.avatarConfig) {
+      this.originalAvatarId = this.profile.avatarConfig.id
       this.avatarConfig = JSON.parse(JSON.stringify(this.profile.avatarConfig))
     } else {
       this.avatarConfig = randomizeOneConfig()
@@ -227,9 +229,6 @@ export class CharacterScene extends Phaser.Scene {
       this.profile.avatarConfig = JSON.parse(JSON.stringify(this.avatarConfig))
       this.profile.avatarChoice = this.avatarConfig.id
       saveProfile(this.profileSlot, this.profile)
-      if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
-        this.textures.remove(this.profile.avatarConfig.id)
-      }
       this.avatarDirty = true
 
       saveBg.setFillStyle(0x44ff44)
@@ -428,9 +427,6 @@ export class CharacterScene extends Phaser.Scene {
       unequipBtn.on('pointerdown', () => {
         this.profile.equipment[slot] = null
         saveProfile(this.profileSlot, this.profile)
-        if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
-          this.textures.remove(this.profile.avatarConfig.id)
-        }
         this.avatarDirty = true
         this.drawActiveTab()
       })
@@ -504,9 +500,6 @@ export class CharacterScene extends Phaser.Scene {
         if (!isEquipped) {
           this.profile.equipment[slot] = item.id
           saveProfile(this.profileSlot, this.profile)
-          if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
-            this.textures.remove(this.profile.avatarConfig.id)
-          }
           this.avatarDirty = true
           this.drawActiveTab()
         }
@@ -591,6 +584,14 @@ export class CharacterScene extends Phaser.Scene {
     if (this.avatarDirty) {
       // Restart OverlandMap so it picks up the new avatar
       this.scene.stop('OverlandMap')
+
+      if (this.originalAvatarId && this.textures.exists(this.originalAvatarId)) {
+        this.textures.remove(this.originalAvatarId)
+      }
+      if (this.profile.avatarConfig && this.textures.exists(this.profile.avatarConfig.id)) {
+        this.textures.remove(this.profile.avatarConfig.id)
+      }
+
       this.scene.start('OverlandMap', { profileSlot: this.profileSlot })
     } else {
       this.scene.resume('OverlandMap')


### PR DESCRIPTION
When a player equips or unequips a weapon (or saves a new avatar configuration) in the Character screen, the game immediately crashes due to a WebGL `TypeError` (`Cannot read properties of undefined`).

This crash occurs because the code previously attempted to destroy the existing cached avatar texture the moment the user clicked the button. However, the `Character` scene is rendered as an overlay on top of the `OverlandMap` scene, which is paused but *still actively rendering its sprites*. By immediately destroying the avatar texture from memory while `OverlandMap` still had active sprites referencing it, Phaser's WebGL renderer crashed on the very next render frame.

This fix safely defers the destruction of the old avatar texture (both the `originalAvatarId` loaded initially, as well as the actively modified `this.profile.avatarConfig.id`) to the `closeScene` method. Now, the textures are only removed from the manager *after* `OverlandMap` has been stopped, guaranteeing no active sprites hold a reference to the deleted texture. When `OverlandMap` restarts shortly after, it safely regenerates the correct, up-to-date avatar texture with the newly equipped items.

---
*PR created automatically by Jules for task [5105706794737442648](https://jules.google.com/task/5105706794737442648) started by @flamableconcrete*