### PR TITLE
Fix pets not collecting coins in boss and level scenes

### DIFF
--- a/src/scenes/boss-types/AncientDragonBoss.ts
+++ b/src/scenes/boss-types/AncientDragonBoss.ts
@@ -253,4 +253,7 @@ export class AncientDragonBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/BaronTypoBoss.ts
+++ b/src/scenes/boss-types/BaronTypoBoss.ts
@@ -269,4 +269,7 @@ export class BaronTypoBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/BoneKnightBoss.ts
+++ b/src/scenes/boss-types/BoneKnightBoss.ts
@@ -327,4 +327,7 @@ export class BoneKnightBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/DiceLichBoss.ts
+++ b/src/scenes/boss-types/DiceLichBoss.ts
@@ -345,4 +345,7 @@ export class DiceLichBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/FlashWordBoss.ts
+++ b/src/scenes/boss-types/FlashWordBoss.ts
@@ -188,4 +188,7 @@ export class FlashWordBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/GrizzlefangBoss.ts
+++ b/src/scenes/boss-types/GrizzlefangBoss.ts
@@ -288,4 +288,7 @@ export class GrizzlefangBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/HydraBoss.ts
+++ b/src/scenes/boss-types/HydraBoss.ts
@@ -362,7 +362,8 @@ export class HydraBoss extends Phaser.Scene {
     })
   }
 
-  update() {
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
     if (this.regrowTimer && !this.finished) {
       const progress = this.regrowTimer.getProgress()
       const barWidth = 200

--- a/src/scenes/boss-types/SlimeKingBoss.ts
+++ b/src/scenes/boss-types/SlimeKingBoss.ts
@@ -258,4 +258,7 @@ export class SlimeKingBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/SpiderBoss.ts
+++ b/src/scenes/boss-types/SpiderBoss.ts
@@ -374,4 +374,7 @@ export class SpiderBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/boss-types/TypemancerBoss.ts
+++ b/src/scenes/boss-types/TypemancerBoss.ts
@@ -323,4 +323,7 @@ export class TypemancerBoss extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/level-types/CharacterCreatorLevel.ts
+++ b/src/scenes/level-types/CharacterCreatorLevel.ts
@@ -70,4 +70,7 @@ export class CharacterCreatorLevel extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/level-types/DungeonEscapeLevel.ts
+++ b/src/scenes/level-types/DungeonEscapeLevel.ts
@@ -136,7 +136,8 @@ export class DungeonEscapeLevel extends Phaser.Scene {
     this.cameras.main.flash(80, 120, 0, 0)
   }
 
-  update() {
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
     // No continuous updates needed
   }
 

--- a/src/scenes/level-types/GuildRecruitmentLevel.ts
+++ b/src/scenes/level-types/GuildRecruitmentLevel.ts
@@ -140,4 +140,7 @@ export class GuildRecruitmentLevel extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/level-types/MagicRuneTypingLevel.ts
+++ b/src/scenes/level-types/MagicRuneTypingLevel.ts
@@ -140,7 +140,8 @@ export class MagicRuneTypingLevel extends Phaser.Scene {
     this.cameras.main.flash(80, 120, 0, 0)
   }
 
-  update() {
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
     // Rotate magic circle slightly
     this.runeContainer.rotation += 0.005
   }

--- a/src/scenes/level-types/MonsterManualLevel.ts
+++ b/src/scenes/level-types/MonsterManualLevel.ts
@@ -130,4 +130,7 @@ export class MonsterManualLevel extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }

--- a/src/scenes/level-types/PotionBrewingLabLevel.ts
+++ b/src/scenes/level-types/PotionBrewingLabLevel.ts
@@ -143,7 +143,8 @@ export class PotionBrewingLabLevel extends Phaser.Scene {
     this.cameras.main.shake(100, 0.01)
   }
 
-  update() {
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
     // No continuous updates needed
   }
 

--- a/src/scenes/level-types/WoodlandFestivalLevel.ts
+++ b/src/scenes/level-types/WoodlandFestivalLevel.ts
@@ -138,4 +138,7 @@ export class WoodlandFestivalLevel extends Phaser.Scene {
       })
     })
   }
+  update(_time: number, delta: number) {
+    this.goldManager?.update(delta)
+  }
 }


### PR DESCRIPTION
Pets were not collecting coins in boss and some level scenes because `this.goldManager.update(delta)` was missing in the `update(time, delta)` method in those scenes. This commit adds the `update` method calls to all relevant scenes.

---
*PR created automatically by Jules for task [16565702256247186340](https://jules.google.com/task/16565702256247186340) started by @flamableconcrete*