### PR TITLE
Fix duplicate update method in BoneKnightBoss

### DIFF
--- a/src/scenes/boss-types/BoneKnightBoss.ts
+++ b/src/scenes/boss-types/BoneKnightBoss.ts
@@ -274,7 +274,9 @@ export class BoneKnightBoss extends Phaser.Scene {
         }
     }
 
-    update() {
+    update(_time: number, delta: number) {
+        this.goldManager?.update(delta)
+
         if (this.finished) return
         
         // Update the active shield text to show progress
@@ -326,8 +328,5 @@ export class BoneKnightBoss extends Phaser.Scene {
                 passed
       })
     })
-  }
-  update(_time: number, delta: number) {
-    this.goldManager?.update(delta)
   }
 }


### PR DESCRIPTION
This submission fixes a TypeScript build failure where `src/scenes/boss-types/BoneKnightBoss.ts` had a duplicate `update` method implementation. The two duplicate implementations were combined into a single method.

I've successfully verified the fix by building the application successfully with `npm run build` and testing that tests still pass.

---
*PR created automatically by Jules for task [1362071763874995870](https://jules.google.com/task/1362071763874995870) started by @flamableconcrete*