### PR TITLE
Remove finger typing hints from CutsceneScene

### DIFF
--- a/src/scenes/CutsceneScene.ts
+++ b/src/scenes/CutsceneScene.ts
@@ -1,6 +1,4 @@
 import Phaser from 'phaser'
-import { TypingHands } from '../components/TypingHands'
-import { loadProfile } from '../utils/profile'
 
 interface CutsceneData {
   letter: string
@@ -58,13 +56,6 @@ export class CutsceneScene extends Phaser.Scene {
       this.tweens.add({ targets: titleText, alpha: 1, duration: 600 })
       this.tweens.add({ targets: announcementText, alpha: 1, duration: 600 })
     })
-
-    // Show finger hint for the restored letter (if enabled)
-    const profile = loadProfile(this.cutsceneData.profileSlot)
-    if (profile?.showFingerHints) {
-      const hands = new TypingHands(this, width / 2, height - 20)
-      hands.highlightFinger(letter)
-    }
 
     const cont = this.add.text(width / 2, height - 40,
       'Press SPACE or click to continue', {


### PR DESCRIPTION
Removed the TypingHands component and associated imports/logic from `CutsceneScene.ts` to ensure the finger typing hints no longer appear on the "letter restored" screen, as requested.

---
*PR created automatically by Jules for task [1921486338634317515](https://jules.google.com/task/1921486338634317515) started by @flamableconcrete*