### PR TITLE
Fix CrazedCookLevel HP decrement

### DIFF
--- a/src/scenes/level-types/CrazedCookLevel.ts
+++ b/src/scenes/level-types/CrazedCookLevel.ts
@@ -52,6 +52,7 @@ export class CrazedCookLevel extends BaseLevelScene {
   private timeLimit!: number
   private maxWalkoffs = 3
   private kitchenController!: KitchenController
+  private playerHp = DEFAULT_PLAYER_HP
 
   constructor() { super('CrazedCookLevel') }
 
@@ -64,6 +65,7 @@ export class CrazedCookLevel extends BaseLevelScene {
     this.orderQuota = data.level.orderQuota
     this.timeLimit = data.level.timeLimit
     this.maxWalkoffs = data.level.maxWalkoffs ?? 3
+    this.playerHp = DEFAULT_PLAYER_HP
   }
 
   create() {
@@ -394,6 +396,13 @@ export class CrazedCookLevel extends BaseLevelScene {
     order.ticket.underlines.forEach(u => u.destroy())
     order.patienceBar.destroy()
     order.patienceBarBg.destroy()
+
+    // HP decrement logic — hook here for future items/defensive effects
+    this.playerHp = Math.max(0, this.playerHp - 1)
+    this.hud?.setHeroHp(this.playerHp)
+    if (this.playerHp <= 0) {
+      this.endLevel(false)
+    }
 
     // Attack tween sequence
     order.orcSprite.setTint(0xff0000)


### PR DESCRIPTION
This change adds tracking of `playerHp` in `CrazedCookLevel` and decreases it by 1 when an orc attacks (walkoff event). It limits `playerHp` to not go below 0 and updates the HUD appropriately. A hook is also left in the code for adding defensive effects later. If `playerHp` hits 0, the level correctly ends in a failure.

---
*PR created automatically by Jules for task [411655348239238033](https://jules.google.com/task/411655348239238033) started by @flamableconcrete*