### PR TITLE
🧹 [code health] Remove commented-out tile index constants

### DIFF
--- a/src/data/maps/world1.ts
+++ b/src/data/maps/world1.ts
@@ -17,7 +17,6 @@ const PATH_H = 2 // horizontal dirt path
 const PATH_V = 3 // vertical dirt path
 const PATH_CORNER = 4 // dirt path corner
 const WATER = 10
-// const WATER_ALT = 11  // used only in animated tile frames
 
 // Decoration indices
 const TREE_TOP = 20

--- a/src/data/maps/world2.ts
+++ b/src/data/maps/world2.ts
@@ -17,7 +17,6 @@ const PATH_H = 2
 const PATH_V = 3
 const PATH_CORNER = 4
 const MURKY_WATER = 10
-// const MURKY_WATER_ALT = 11  // used only in animated tile frames
 
 // Decoration indices
 const DEAD_TREE_TOP = 20

--- a/src/data/maps/world3.ts
+++ b/src/data/maps/world3.ts
@@ -19,7 +19,6 @@ const PATH_CORNER = 4
 const ASH_STONE = 5
 const CRACKED_EARTH = 6
 const LAVA_1 = 10
-// const LAVA_2 = 11  // used only in animated tile frames
 
 // Decoration indices
 const OBSIDIAN_SPIRE = 20

--- a/src/data/maps/world4.ts
+++ b/src/data/maps/world4.ts
@@ -19,7 +19,6 @@ const PATH_CORNER = 4
 const TANGLED_ROOTS = 5
 const OVERGROWN_STONE = 6
 const DEEP_MOSS = 10
-// const DEEP_MOSS_ALT = 11  // used only in animated tile frames
 
 // Decoration indices
 const MUSHROOM_RED = 20

--- a/src/data/maps/world5.ts
+++ b/src/data/maps/world5.ts
@@ -18,7 +18,6 @@ const PATH_V = 3
 const PATH_CORNER = 4
 const FLOATING_STONE = 5
 const VOID_1 = 10
-// const VOID_2 = 11  // used only in animated tile frames
 
 // Decoration indices
 const CRYSTAL_PILLAR = 20


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed commented-out tile index constants (e.g., `WATER_ALT`, `MURKY_WATER_ALT`, `LAVA_2`, `DEEP_MOSS_ALT`, `VOID_2`) in `src/data/maps/world1.ts` through `src/data/maps/world5.ts`.

💡 **Why:** How this improves maintainability
- Removing dead code improves readability and reduces clutter.
- Version control history is sufficient for tracking these values if they were ever needed again.

✅ **Verification:** How you confirmed the change is safe
- Verified that these constants were not referenced anywhere in the codebase using `grep`.
- Confirmed that the values were indeed commented out and redundant.

✨ **Result:** The improvement achieved
- Cleaner and more maintainable map data files.

---
*PR created automatically by Jules for task [14052569781601443960](https://jules.google.com/task/14052569781601443960) started by @flamableconcrete*