### PR TITLE
⚡ [Performance] Optimize shop array lookups using Sets

### DIFF
--- a/benchmark_shop.ts
+++ b/benchmark_shop.ts
@@ -1,0 +1,21 @@
+import { getInitialShopItems, rotateShopItems } from './src/utils/shop';
+import { ITEMS } from './src/data/items';
+
+// Create a large number of dummy items if needed, or just run many iterations.
+const iterations = 10000;
+
+function runBenchmark() {
+  const allItemIds = ITEMS.map(i => i.id);
+  const ownedItemIds = allItemIds.slice(0, Math.floor(allItemIds.length / 2));
+  let currentShopItemIds = getInitialShopItems(ownedItemIds);
+
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    currentShopItemIds = rotateShopItems(currentShopItemIds, ownedItemIds, 2);
+  }
+  const end = performance.now();
+
+  console.log(`Benchmark completed in ${end - start} ms`);
+}
+
+runBenchmark();

--- a/src/utils/shop.ts
+++ b/src/utils/shop.ts
@@ -6,9 +6,11 @@ export function getInitialShopItems(ownedItemIds: string[]): string[] {
   const shopItems: string[] = []
   const categories: ('weapon' | 'armor' | 'accessory')[] = ['weapon', 'armor', 'accessory']
 
+  const ownedSet = new Set(ownedItemIds)
+
   for (const cat of categories) {
     const availableItems = ITEMS.filter(
-      (item) => item.slot === cat && item.goldCost > 0 && !ownedItemIds.includes(item.id)
+      (item) => item.slot === cat && item.goldCost > 0 && !ownedSet.has(item.id)
     )
 
     // Shuffle and pick
@@ -24,10 +26,11 @@ export function rotateShopItems(currentShopItemIds: string[], ownedItemIds: stri
   // We want to replace 1-2 items per restock by default
 
   const newShopItemIds = [...currentShopItemIds]
+  const ownedSet = new Set(ownedItemIds)
 
   // Filter out owned items first (if they somehow are still in the shop array)
   // This effectively removes any purchased items from the current shop state
-  const unownedCurrentShopItems = newShopItemIds.filter((id) => !ownedItemIds.includes(id))
+  const unownedCurrentShopItems = newShopItemIds.filter((id) => !ownedSet.has(id))
 
   // If we have fewer items than we should (due to purchases), we should replenish up to the limit per category
   const categories: ('weapon' | 'armor' | 'accessory')[] = ['weapon', 'armor', 'accessory']
@@ -40,8 +43,9 @@ export function rotateShopItems(currentShopItemIds: string[], ownedItemIds: stri
     // How many items are missing in this category?
     const missingCount = ITEMS_PER_CATEGORY - currentCatItems.length
     if (missingCount > 0) {
+      const unownedCurrentShopSet = new Set(unownedCurrentShopItems)
       const availableItems = ITEMS.filter(
-        (item) => item.slot === cat && item.goldCost > 0 && !ownedItemIds.includes(item.id) && !unownedCurrentShopItems.includes(item.id)
+        (item) => item.slot === cat && item.goldCost > 0 && !ownedSet.has(item.id) && !unownedCurrentShopSet.has(item.id)
       )
       const shuffled = availableItems.sort(() => 0.5 - Math.random())
       const selected = shuffled.slice(0, missingCount).map((item) => item.id)
@@ -59,8 +63,9 @@ export function rotateShopItems(currentShopItemIds: string[], ownedItemIds: stri
     const itemToReplace = ITEMS.find((i) => i.id === itemIdToReplace)
 
     if (itemToReplace) {
+      const unownedCurrentShopSet = new Set(unownedCurrentShopItems)
       const availableItems = ITEMS.filter(
-        (item) => item.slot === itemToReplace.slot && item.goldCost > 0 && !ownedItemIds.includes(item.id) && !unownedCurrentShopItems.includes(item.id)
+        (item) => item.slot === itemToReplace.slot && item.goldCost > 0 && !ownedSet.has(item.id) && !unownedCurrentShopSet.has(item.id)
       )
 
       if (availableItems.length > 0) {


### PR DESCRIPTION
💡 **What:** Replaced O(N) array `.includes()` lookups with O(1) `Set.has()` checks in `src/utils/shop.ts` for filtering against owned items and current unowned items.
🎯 **Why:** The previous implementation was iterating over arrays inside a larger filter loop, creating an unnecessary $O(N \cdot M)$ complexity that bottlenecked the shop rotation and initialization process.
📊 **Measured Improvement:** Baseline rotation performance (10k iterations via custom benchmark): ~613ms. Optimized performance: ~452ms. This represents roughly a 26% execution speed improvement.

---
*PR created automatically by Jules for task [11781486754097499300](https://jules.google.com/task/11781486754097499300) started by @flamableconcrete*