### PR TITLE
🧪 Add unit tests for setupPause fallback behavior

### DIFF
--- a/src/utils/pauseSetup.test.ts
+++ b/src/utils/pauseSetup.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { setupPause } from './pauseSetup'
+
+describe('setupPause', () => {
+  it('should be a function', () => {
+    expect(typeof setupPause).toBe('function')
+  })
+
+  it('should execute without error', () => {
+    const mockScene = {
+      input: {
+        keyboard: {
+          on: vi.fn(),
+        },
+      },
+    } as any
+
+    expect(() => setupPause(mockScene, 0)).not.toThrow()
+  })
+
+  it('should not add any keyboard listeners (since logic moved to LevelHUD)', () => {
+    const mockScene = {
+      input: {
+        keyboard: {
+          on: vi.fn(),
+        },
+      },
+    } as any
+
+    setupPause(mockScene, 0)
+    expect(mockScene.input.keyboard.on).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR adds unit tests for the `setupPause` utility function in `src/utils/pauseSetup.ts`. 

Since the pause logic was moved to `LevelHUD`, `setupPause` now acts as a placeholder fallback. These tests ensure that the function remains safe to call during scene initialization and does not have any unintended side effects, such as registering redundant event listeners.

Tests were implemented using Vitest and verified through manual logic checks due to environment constraints.

---
*PR created automatically by Jules for task [8866330899378954191](https://jules.google.com/task/8866330899378954191) started by @flamableconcrete*