### PR TITLE
🧪 [Testing] Add missing coverage for profile import playerName validation

### DIFF
--- a/src/utils/profile.test.ts
+++ b/src/utils/profile.test.ts
@@ -53,6 +53,12 @@ describe('profile system', () => {
     expect(importProfile('not-json')).toBeNull()
   })
 
+  it('importProfile returns null if playerName is missing or invalid', () => {
+    expect(importProfile('{}')).toBeNull()
+    expect(importProfile('{"playerName": 123}')).toBeNull()
+    expect(importProfile('{"otherField": "value"}')).toBeNull()
+  })
+
   it('creates profile with gameMode regular by default', () => {
     const p = createProfile('Hero')
     expect(p.gameMode).toBe('regular')


### PR DESCRIPTION
🎯 **What:** The `importProfile` function contained a check for missing or invalid `playerName` properties when loading JSON objects (`if (typeof data.playerName !== 'string') return null`), but this condition lacked test coverage. 
📊 **Coverage:** Added scenarios verifying that parsing an empty object `{}`, an object with an invalid type for the field `{"playerName": 123}`, or an object completely missing the required field `{"otherField": "value"}` correctly returns `null`.
✨ **Result:** Enhanced unit test suite coverage and safeguards the `importProfile` function against bad data regression.

---
*PR created automatically by Jules for task [2965621907271748092](https://jules.google.com/task/2965621907271748092) started by @flamableconcrete*